### PR TITLE
added output formats for timestamps in raw format

### DIFF
--- a/bin/nf_common.c
+++ b/bin/nf_common.c
@@ -1877,13 +1877,13 @@ static void String_ReceivedRaw(master_record_t *r, char *string)
 static void String_FirstSeenRaw(master_record_t *r, char *string)
 {
 	 /* snprintf does write \0, and the max is INCL the terminating \0 */
-	 snprintf(string, MAX_STRING_LENGTH, "%.3f", r->first/1000.0);
+	 snprintf(string, MAX_STRING_LENGTH, "%u.%03u", r->first, r->msec_first);
 }
 
 static void String_LastSeenRaw(master_record_t *r, char *string)
 {
 	 /* snprintf does write \0, and the max is INCL the terminating \0 */
-	 snprintf(string, MAX_STRING_LENGTH, "%.3f", r->last/1000.0);
+	 snprintf(string, MAX_STRING_LENGTH, "%u.%03u", r->last, r->msec_last);
 }
 
 

--- a/bin/nf_common.c
+++ b/bin/nf_common.c
@@ -104,6 +104,12 @@ static void String_LastSeen(master_record_t *r, char *string);
 
 static void String_Received(master_record_t *r, char *string);
 
+static void String_FirstSeenRaw(master_record_t *r, char *string);
+
+static void String_LastSeenRaw(master_record_t *r, char *string);
+
+static void String_ReceivedRaw(master_record_t *r, char *string);
+
 static void String_Duration(master_record_t *r, char *string);
 
 static void String_Protocol(master_record_t *r, char *string);
@@ -274,8 +280,11 @@ static struct format_token_list_s {
 	{ "%ff", 0, "Flow Flags", 				String_FlowFlags }, 	// flow flags in hex
 	{ "%tfs", 0, "Date first seen        ", String_FirstSeen },		// Start Time - first seen
 	{ "%ts",  0, "Date first seen        ", String_FirstSeen },		// Start Time - first seen
+	{ "%tsr",  0, "Date first seen (raw)    ", String_FirstSeenRaw },		// Start Time - first seen, seconds
 	{ "%te",  0, "Date last seen         ", String_LastSeen },		// End Time	- last seen
+	{ "%ter",  0, "Date last seen (raw)     ", String_LastSeenRaw },		// End Time - first seen, seconds
 	{ "%tr",  0, "Date flow received     ", String_Received },		// Received Time
+	{ "%trr",  0, "Date flow received (raw)  ", String_ReceivedRaw },		// Received Time, seconds
 	{ "%td",  0, " Duration", 				String_Duration },		// Duration
 	{ "%exp", 0, "Exp ID", 				 	String_ExpSysID },		// Exporter SysID
 	{ "%pr",  0, "Proto", 					String_Protocol },		// Protocol
@@ -1858,6 +1867,25 @@ char 	*s;
 	string[MAX_STRING_LENGTH-1] = '\0';
 
 } // End of String_Received
+
+static void String_ReceivedRaw(master_record_t *r, char *string)
+{
+	 /* snprintf does write \0, and the max is INCL the terminating \0 */
+	 snprintf(string, MAX_STRING_LENGTH, "%.3f", r->received/1000.0);
+}
+
+static void String_FirstSeenRaw(master_record_t *r, char *string)
+{
+	 /* snprintf does write \0, and the max is INCL the terminating \0 */
+	 snprintf(string, MAX_STRING_LENGTH, "%.3f", r->first/1000.0);
+}
+
+static void String_LastSeenRaw(master_record_t *r, char *string)
+{
+	 /* snprintf does write \0, and the max is INCL the terminating \0 */
+	 snprintf(string, MAX_STRING_LENGTH, "%.3f", r->last/1000.0);
+}
+
 
 #ifdef NSEL
 static void String_EventTime(master_record_t *r, char *string) {

--- a/man/nfdump.1
+++ b/man/nfdump.1
@@ -601,9 +601,15 @@ and format specifier as described below
 .br
 \fB%ts\fR       Start Time \- first seen
 .br
+\fB%tsr\fR      Start Time, but in fractional seconds since the epoch (1970-01-01)
+.br
 \fB%te\fR       End Time \- last seen
 .br
+\fB%ter\fR      End Time, in fractional seconds
+.br
 \fB%tr\fR       Time the flow was received by the collector
+.br
+\fB%trr\fR      Time the flow was received, in fractional seconds
 .br
 \fB%td\fR       Duration
 .br


### PR DESCRIPTION
when post-processing nfdump's output it is quite wasteful to first have nfdump produce iso8601-like strings and then having to parse them back into seconds since the unix epoch.

i've added %trr, %tsr and %ter (analogues to %tr, %ts and %te) which produce fractional seconds for their respective timestamps; the man page was updated.