### PR TITLE
FIX #32. Makefile.am for parallel building

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -66,30 +66,36 @@ libnfdump_la_LDFLAGS = -release 1.6.15
 nfdump_SOURCES = nfdump.c nfdump.h nfstat.c nfstat.h nfexport.c nfexport.h  \
 	$(nflowcache) $(nfprof)
 nfdump_LDADD = -lnfdump
+nfdump_DEPENDENCIES = libnfdump.la
 
 nfreplay_SOURCES = nfreplay.c $(nfprof) \
 	$(nfnet) $(collector) $(nfv1) $(nfv9) $(nfv5v7) $(ipfix)
 nfreplay_LDADD = -lnfdump
+nfreplay_DEPENDENCIES = libnfdump.la
 
 nfprofile_SOURCES = nfprofile.c profile.c profile.h $(nfstatfile) 
 nfprofile_LDADD = -lnfdump -lrrd
+nfprofile_DEPENDENCIES = libnfdump.la
 
 nftrack_SOURCES = ../extra/nftrack/nftrack.c \
 	../extra/nftrack/nftrack_rrd.c ../extra/nftrack/nftrack_rrd.h \
 	../extra/nftrack/nftrack_stat.c ../extra/nftrack/nftrack_stat.h 
 nftrack_CFLAGS = -I ../extra/nftrack
 nftrack_LDADD = -lnfdump -lrrd
+nftrack_DEPENDENCIES = libnfdump.la
 
 nfcapd_SOURCES = nfcapd.c \
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(nfv1) $(nfv5v7) $(nfv9) $(ipfix) $(bookkeeper) $(expire)
 nfcapd_LDADD = -lnfdump 
+nfcapd_DEPENDENCIES = libnfdump.la
 
 nfpcapd_SOURCES = nfpcapd.c \
 	$(pcaproc) $(netflow_pcap) \
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(bookkeeper) $(expire) $(content)
 nfpcapd_LDADD = -lnfdump 
+nfpcapd_DEPENDENCIES = libnfdump.la
 
 if READPCAP
 nfcapd_CFLAGS = -DPCAP
@@ -108,6 +114,7 @@ sfcapd_SOURCES = sfcapd.c sflow.c sflow.h sflow_proto.h \
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(bookkeeper) $(expire)
 sfcapd_LDADD = -lnfdump 
+sfcapd_DEPENDENCIES = libnfdump.la
 
 if READPCAP
 sfcapd_CFLAGS = -DPCAP
@@ -117,26 +124,31 @@ endif
 
 nfreader_SOURCES = nfreader.c 
 nfreader_LDADD = -lnfdump 
+nfreader_DEPENDENCIES = libnfdump.la
 
 nfanon_SOURCES = nfanon.c $(anon)
 nfanon_LDADD = -lnfdump 
+nfanon_DEPENDENCIES = libnfdump.la
 
 nfgen_SOURCES = nfgen.c 
 nfgen_LDADD = -lnfdump 
+nfgen_DEPENDENCIES = libnfdump.la
 
 nfexpire_SOURCES = nfexpire.c \
 	$(bookkeeper) $(expire) $(nfstatfile)
 nfexpire_LDADD = -lnfdump @FTS_OBJ@
+nfexpire_DEPENDENCIES = libnfdump.la
 
 nftest_SOURCES = nftest.c 
 nftest_LDADD = -lnfdump 
-nftest_DEPENDENCIES = nfgen
+nftest_DEPENDENCIES = nfgen libnfdump.la
 
 if FT2NFDUMP
 ft2nfdump_SOURCES = ft2nfdump.c 
 ft2nfdump_CFLAGS = @FT_INCLUDES@
 ft2nfdump_LDADD = -lnfdump -lft -lz
 ft2nfdump_LDADD += @FT_LDFLAGS@
+ft2nfdump_DEPENDENCIES = libnfdump.la
 endif
 
 check_DIST = inline.c collector_inline.c nffile_inline.c nfdump_inline.c heapsort_inline.c applybits_inline.c 


### PR DESCRIPTION
This fixes parallel build (make -j2), issue #32 

Testing speed and deterministic build.

```
./bootstrap
./configure
time make
#21seconds

md5sum bin/* > hash.txt
make clean
time make -j8
#5seconds

md5sum -c hash.txt
#Everything OK
```
