### PR TITLE
Cisco ASA fixes for packet counters, report format

### DIFF
--- a/bin/netflow_v9.c
+++ b/bin/netflow_v9.c
@@ -325,6 +325,12 @@ static struct v9_element_map_s {
 	// byte count
 	{ NF_F_FLOW_BYTES, 			 "ASA bytes",				_4bytes,  _8bytes, move32_sampling, zero64, EX_NSEL_COMMON },
 	{ NF_F_FLOW_BYTES, 			 "ASA bytes",				_8bytes,  _8bytes, move64_sampling, zero64, EX_NSEL_COMMON },
+	// packet count
+	{ NF_F_IN_PACKETS, 			 "ASA in packets",		_4bytes,  _8bytes, move32_sampling, zero64, EX_NSEL_COMMON },
+	{ NF_F_IN_PACKETS, 			 "ASA in packets",		_8bytes,  _8bytes, move64_sampling, zero64, EX_NSEL_COMMON },
+	{ NF_F_OUT_PACKETS, 		 "ASA out packets",		_4bytes,  _8bytes, move32_sampling, zero64, EX_OUT_PKG_8 },
+	{ NF_F_OUT_PACKETS, 		 "ASA out packets",		_8bytes,  _8bytes, move64_sampling, zero64, EX_OUT_PKG_8 },
+
 	{ NF_F_FWD_FLOW_DELTA_BYTES, "ASA fwd bytes",			_4bytes,  _8bytes, move32_sampling, zero64, EX_NSEL_COMMON },
 	{ NF_F_FWD_FLOW_DELTA_BYTES, "ASA fwd bytes",			_8bytes,  _8bytes, move64_sampling, zero64, EX_NSEL_COMMON },
 	{ NF_F_REV_FLOW_DELTA_BYTES,  "ASA rew bytes",			_4bytes,  _4bytes, move32_sampling, zero32, EX_OUT_BYTES_4 },
@@ -783,7 +789,12 @@ size_t				size_required;
 	 * This record is expected in the output stream. If not available
 	 * in the template, assume empty 4 bytes value
 	 */
+	// ASA 9.x: pkt counters in (unpublished) records 298 and 299 (see EX_OUT_PKG below)
+	if ( cache.lookup_info[NF_F_IN_PACKETS].found ) {
+		PushSequence( table, NF_F_IN_PACKETS, &offset, &table->packets, 0);
+	} else {
 	PushSequence( table, NF9_IN_PACKETS, &offset, &table->packets, 0);
+	}
 	// fix: always have 64bit counters due to possible sampling
 	SetFlag(table->flags, FLAG_PKG_64);
 
@@ -863,10 +874,18 @@ size_t				size_required;
 				PushSequence( table, NF9_DST_VLAN, &offset, NULL, 0);
 				break;
 			case EX_OUT_PKG_4:
+			  if ( cache.lookup_info[NF_F_OUT_PACKETS].found ) {
+				  PushSequence( table, NF_F_OUT_PACKETS, &offset, &table->out_packets, 0);
+				} else {
 				PushSequence( table, NF9_OUT_PKTS, &offset, &table->out_packets, 0);
+			  }
 				break;
 			case EX_OUT_PKG_8:
+			  if ( cache.lookup_info[NF_F_OUT_PACKETS].found ) {
+				  PushSequence( table, NF_F_OUT_PACKETS, &offset, &table->out_packets, 0);
+				} else {
 				PushSequence( table, NF9_OUT_PKTS, &offset, &table->out_packets, 0);
+			  }
 				break;
 			case EX_OUT_BYTES_4:
 				if ( cache.lookup_info[NF_F_REV_FLOW_DELTA_BYTES].found ) {

--- a/bin/netflow_v9.c
+++ b/bin/netflow_v9.c
@@ -789,7 +789,7 @@ size_t				size_required;
 	 * This record is expected in the output stream. If not available
 	 * in the template, assume empty 4 bytes value
 	 */
-	// ASA 9.x: pkt counters in (unpublished) records 298 and 299 (see EX_OUT_PKG below)
+	// ASA 9.x: pkt counters in initiatorPackets and responderPackets
 	if ( cache.lookup_info[NF_F_IN_PACKETS].found ) {
 		PushSequence( table, NF_F_IN_PACKETS, &offset, &table->packets, 0);
 	} else {
@@ -874,6 +874,7 @@ size_t				size_required;
 				PushSequence( table, NF9_DST_VLAN, &offset, NULL, 0);
 				break;
 			case EX_OUT_PKG_4:
+	     // ASA 9.x: pkt counters in initiatorPackets and responderPackets
 			  if ( cache.lookup_info[NF_F_OUT_PACKETS].found ) {
 				  PushSequence( table, NF_F_OUT_PACKETS, &offset, &table->out_packets, 0);
 				} else {
@@ -881,6 +882,7 @@ size_t				size_required;
 			  }
 				break;
 			case EX_OUT_PKG_8:
+	      // ASA 9.x: pkt counters in initiatorPackets and responderPackets
 			  if ( cache.lookup_info[NF_F_OUT_PACKETS].found ) {
 				  PushSequence( table, NF_F_OUT_PACKETS, &offset, &table->out_packets, 0);
 				} else {

--- a/bin/netflow_v9.h
+++ b/bin/netflow_v9.h
@@ -290,6 +290,10 @@ typedef struct common_header_s {
 #define NF_F_XLATE_DST_PORT_84      40004
 #define NF_F_FW_EVENT_84            40005
 
+// ASA 9.x packet counters
+#define NF_F_IN_PACKETS       298
+#define NF_F_OUT_PACKETS      299
+
 // Cisco ASR 1000 series NEL extension - Nat Event Logging
 #define NF_N_NAT_EVENT				230
 #define NF_N_INGRESS_VRFID			234

--- a/bin/netflow_v9.h
+++ b/bin/netflow_v9.h
@@ -290,7 +290,8 @@ typedef struct common_header_s {
 #define NF_F_XLATE_DST_PORT_84      40004
 #define NF_F_FW_EVENT_84            40005
 
-// ASA 9.x packet counters
+// ASA 9.x packet counters: initiatorPackets and responderPackets
+// see https://www.iana.org/assignments/ipfix/ipfix.xhtml
 #define NF_F_IN_PACKETS       298
 #define NF_F_OUT_PACKETS      299
 

--- a/bin/nfdump.c
+++ b/bin/nfdump.c
@@ -189,6 +189,12 @@ extern generic_exporter_t **exporter_list;
 
 #define FORMAT_nel "%ts %nevt %pr %sap -> %dap %nsap -> %ndap"
 
+#define FORMAT_asa    "%evt|%xevt|%nfc|%msec|%ts|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+
+#define FORMAT_asaexp "%evt|%xevt|%nfc|%ts|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+
+#define FORMAT_asaagg "%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+
 #ifdef NSEL
 #	define DefaultMode "nsel"
 #else 
@@ -224,6 +230,9 @@ printmap_t printmap[] = {
 	{ "extended",	format_special, 			FORMAT_extended	},
 	{ "biline", 	format_special,      		FORMAT_biline 	},
 	{ "bilong", 	format_special,      		FORMAT_bilong 	},
+	{ "asa", 	format_special,      		FORMAT_asa 	},
+	{ "asaexp", 	format_special,      		FORMAT_asaexp 	},
+	{ "asaagg", 	format_special,      		FORMAT_asaagg 	},
 	{ "pipe", 		flow_record_to_pipe,      	NULL 			},
 	{ "json", 		flow_record_to_json,      	NULL 			},
 	{ "csv", 		flow_record_to_csv,      	NULL 			},

--- a/bin/nfdump.c
+++ b/bin/nfdump.c
@@ -189,11 +189,21 @@ extern generic_exporter_t **exporter_list;
 
 #define FORMAT_nel "%ts %nevt %pr %sap -> %dap %nsap -> %ndap"
 
-#define FORMAT_asa    "%evt|%xevt|%nfc|%msec|%ts|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+#define FORMAT_asa    "%evt|%xevt|%nfc|%ts|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
 
-#define FORMAT_asaexp "%evt|%xevt|%nfc|%ts|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+#define FORMAT_asaexp "%evt|%xevt|%nfc|%msec|%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
 
-#define FORMAT_asaagg "%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt"
+#define FORMAT_asaagg "%pr|%in|%sa|%sp|%out|%da|%dp|%ibyt|%obyt|%ipkt|%opkt|%fl"
+
+#define FORMAT_bitab  "%ts|%pr|%flg|%tos|%in|%sa|%sp|%out|%da|%dp|%ibyt|%ipkt|%obyt|%opkt"
+
+#define FORMAT_biexp  "%msec|%pr|%flg|%tos|%in|%sa|%sp|%out|%da|%dp|%ibyt|%ipkt|%obyt|%opkt"
+
+#define FORMAT_tab    "%ts|%pr|%flg|%tos|%in|%sa|%sp|%out|%da|%dp|%ibyt|%ipkt"
+
+#define FORMAT_tabexp "%msec|%pr|%flg|%tos|%in|%sa|%sp|%out|%da|%dp|%ibyt|%ipkt"
+
+#define FORMAT_tabagg "%pr|%flg|%tos|%in|%sa|%sp|%out|%da|%dp|%ibyt|%ipkt|%fl"
 
 #ifdef NSEL
 #	define DefaultMode "nsel"
@@ -233,6 +243,11 @@ printmap_t printmap[] = {
 	{ "asa", 	format_special,      		FORMAT_asa 	},
 	{ "asaexp", 	format_special,      		FORMAT_asaexp 	},
 	{ "asaagg", 	format_special,      		FORMAT_asaagg 	},
+	{ "bitab",  format_special,      		FORMAT_bitab 	},
+	{ "biexp",  format_special,      		FORMAT_biexp 	},
+	{ "tab",    format_special,      		FORMAT_tab 	},
+	{ "tabexp", format_special,      		FORMAT_tabexp 	},
+	{ "tabagg", format_special,      		FORMAT_tabagg 	},
 	{ "pipe", 		flow_record_to_pipe,      	NULL 			},
 	{ "json", 		flow_record_to_json,      	NULL 			},
 	{ "csv", 		flow_record_to_csv,      	NULL 			},


### PR DESCRIPTION
Cisco ASA v9.8(2)20 incorrectly exports packet counters for bidirectional flows (they are in undocumented attributes 298 and 299). This PR adds auto-detection of those attributes to nfcapd (fixes issue #115 ).

3 output formats suitable for viewing ASA flows are also included (`asa` for flows, `asaagg` for aggregation, `asaexp` for csv-like export): existent formats are missing some pieces of information from ASA flows. Output of patched nfdump looks like this: 

```
[alex@v-centos7 asa]$ nfdump -r nfcapd.201805241050 -o asa -c 4
 Event  XEvent    Conn-ID Date first seen         Proto  Input      Src IP Addr Src Pt Output      Dst IP Addr Dst Pt  In Byte Out Byte   In Pkt  Out Pkt
DELETE|   2032| 123509628|2018-05-24 10:50:35.456|TCP  |     9|  212.47.219.218| 43842|     4|  195.218.150.10| 50022|    2877|    4167|      21|      21
CREATE| Ignore| 123509956|2018-05-24 10:50:51.836|TCP  |     9|  212.47.219.218| 47255|     4|  195.218.150.10| 50022|       0|       0|       0|       0
DENIED|  I-ACL|         0|2018-05-24 10:50:51.836|TCP  |     2|      10.1.10.75| 47522|     9|    95.216.3.190|   443|       0|       0|       0|       0
UPDATE| Ignore| 123508413|2018-05-24 10:49:49.967|TCP  |     2|      10.0.50.10| 38046|     3|       10.1.78.5|  3128|    1320|    3378|      12|      12
```
