### PR TITLE
Scale numeric values in summary unless -N is used.

### DIFF
--- a/bin/nfdump.c
+++ b/bin/nfdump.c
@@ -348,11 +348,11 @@ char 		bps_str[NUMBER_STRING_SIZE], pps_str[NUMBER_STRING_SIZE], bpp_str[NUMBER_
 			(long long unsigned)stat_record->numpackets, (long long unsigned)bps, 
 			(long long unsigned)pps, (long long unsigned)bpp );
 	} else {
-		format_number(stat_record->numbytes, byte_str, DONT_SCALE_NUMBER, VAR_LENGTH);
-		format_number(stat_record->numpackets, packet_str, DONT_SCALE_NUMBER, VAR_LENGTH);
-		format_number(bps, bps_str, DONT_SCALE_NUMBER, VAR_LENGTH);
-		format_number(pps, pps_str, DONT_SCALE_NUMBER, VAR_LENGTH);
-		format_number(bpp, bpp_str, DONT_SCALE_NUMBER, VAR_LENGTH);
+		format_number(stat_record->numbytes, byte_str, DO_SCALE_NUMBER, VAR_LENGTH);
+		format_number(stat_record->numpackets, packet_str, DO_SCALE_NUMBER, VAR_LENGTH);
+		format_number(bps, bps_str, DO_SCALE_NUMBER, VAR_LENGTH);
+		format_number(pps, pps_str, DO_SCALE_NUMBER, VAR_LENGTH);
+		format_number(bpp, bpp_str, DO_SCALE_NUMBER, VAR_LENGTH);
 		printf("Summary: total flows: %llu, total bytes: %s, total packets: %s, avg bps: %s, avg pps: %s, avg bpp: %s\n",
 		(unsigned long long)stat_record->numflows, byte_str, packet_str, bps_str, pps_str, bpp_str );
 	}


### PR DESCRIPTION
Summary often contains large numbers that are hard to read on first sight. This patch enables scaling also on summary numeric values by default: 

Summary: total flows: 211, total bytes: 614.1 M, total packets: 6.9 M, avg bps: 16.4 M, avg pps: 23142, avg bpp: 88

Exact numbers are provided with -N option:

Summary: total flows: 211, total bytes: 614119114, total packets: 6913837, avg bps: 16444975, avg pps: 23142, avg bpp: 88