### PR TITLE
Fix typo in protolist: element 87 should be "TCF" but is instead "TCP".

### DIFF
--- a/bin/nf_common.c
+++ b/bin/nf_common.c
@@ -493,7 +493,7 @@ char protolist[NumProtos][MAX_PROTO_STR] = {
 	"TTP  ",    // 84	TTP
 	"NSIGP",    // 85	NSFNET-IGP
 	"DGP  ",    // 86	Dissimilar Gateway Protocol
-	"TCP  ",    // 87	TCF
+	"TCF  ",    // 87	TCF
 	"EIGRP",    // 88	EIGRP
 	"OSPF ",    // 89	OSPFIGP
 	"S-RPC",    // 90	Sprite RPC Protocol


### PR DESCRIPTION
Overloaded string "TCP" causing confusion when nfdump output contains both protocol 6 and protocol 87 flows. Fixes issue 130.