### PR TITLE
move ERROR messages to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Extensions: nfcapd supports a large number of v9 tags. In order to optimise
 disk space and performance, v9 tags are grouped into a number of extensions
 which may or may not be stored into the data file. Therefore the v9 templates configured on the exporter may be tuned with the collector. Only the tags common to both are stored into the data files. Extensions can be switch on/off by using the -T option. If you want to collect all data, use __-Tall__
 
-###Sampling
+### Sampling
 By default, the sampling rate is set to 1 (unsampled) or to 
 any given value specified by the -s cmd line option. If sampling information is found 
 in the netflow stream, it overwrites the default value. Sampling is automatically 
@@ -403,7 +403,7 @@ netflow data, even if sampling is configured. The number of bytes/packets in eac
 netflow record is automatically multiplied by the sampling rate. The total number of 
 flows is not changed as this is not accurate enough. (Small flows versus large flows)
 
-###InfluxDB
+### InfluxDB
 You can send nfprofile stats data to an influxdb database. The data are the same of rrd files.
 For enable this option you need libcurl dev package installed, use --enable-influxdb for configure the project and the nfprofile command should be invoked with option: -i <influxurl> . 
 Example: -i http://localhost:8086/write?db=mydb&u=user&p=pass 

--- a/bin/flist.c
+++ b/bin/flist.c
@@ -764,7 +764,7 @@ printf("file_list_level: %i\n", file_list_level);
 		}
 
 		if ( ftsent->fts_pathlen < sub_index ) {
-			printf("ERROR: fts_pathlen error at %s line %d\n", __FILE__, __LINE__);
+			fprintf(stderr, "ERROR: fts_pathlen error at %s line %d\n", __FILE__, __LINE__);
 			exit(250);
 		}
 		fts_path = &ftsent->fts_path[sub_index];

--- a/bin/netflow_v9.c
+++ b/bin/netflow_v9.c
@@ -688,7 +688,7 @@ size_t				size_required;
 		table->extension_map_changed = 1;
 #ifdef DEVEL
 		if ( !GetTranslationTable(exporter, id) ) {
-			printf("*** ERROR failed to crosscheck translation table\n");
+			fprintf(stderr, "*** ERROR failed to crosscheck translation table\n");
 		} else {
 			printf("table lookup ok!\n");
 		}

--- a/bin/nfx.c
+++ b/bin/nfx.c
@@ -163,7 +163,7 @@ int i;
 	i = 1;
 	while ( extension_descriptor[i].id ) {
 		if ( extension_descriptor[i].id != i ) {
-			printf("*** ERROR *** Init extension_descriptors at index %i: ID: %i, %s\n", 
+			fprintf(stderr, "*** ERROR *** Init extension_descriptors at index %i: ID: %i, %s\n", 
 				i, extension_descriptor[i].id, extension_descriptor[i].description);
 		}
 		i++;
@@ -486,7 +486,7 @@ int i, failed, extension_size, max_elements;
 	}
 
 	if ( ((int)map->size - (int)sizeof(extension_map_t)) <= 0 ) {
-		printf("Verify map id %i: ERROR: map size %i too small!\n", map->map_id, map->size);
+		fprintf(stderr, "Verify map id %i: ERROR: map size %i too small!\n", map->map_id, map->size);
 		failed = 1;
 		return 0;
 	}
@@ -497,7 +497,7 @@ int i, failed, extension_size, max_elements;
 	while (map->ex_id[i] && i <= max_elements) {
 		int id = map->ex_id[i];
 		if ( id > Max_num_extensions ) {
-			printf("Verify map id %i: ERROR: element id %i out of range [%i]!\n", map->map_id, id, Max_num_extensions);
+			fprintf(stderr, "Verify map id %i: eRROR: element id %i out of range [%i]!\n", map->map_id, id, Max_num_extensions);
 			failed = 1;
 		}
 		extension_size += extension_descriptor[id].size;
@@ -505,13 +505,13 @@ int i, failed, extension_size, max_elements;
 	}
 
 	if ( (extension_size != map->extension_size ) ) {
-		printf("Verify map id %i: ERROR extension size: Expected %i, Map reports: %i!\n",  map->map_id,
+		fprintf(stderr, "Verify map id %i: ERROR extension size: Expected %i, Map reports: %i!\n",  map->map_id,
 			extension_size, map->extension_size);
 		failed = 1;
 	}
 	if ( (i != max_elements ) && ((max_elements-i) != 1) ) {
 		// off by 1 is the opt alignment
-		printf("Verify map id %i: ERROR: Expected %i elements in map, but found %i!\n", map->map_id, max_elements, i);
+		fprintf(stderr, "Verify map id %i: ERROR: Expected %i elements in map, but found %i!\n", map->map_id, max_elements, i);
 		failed = 1;
 	}
 
@@ -531,7 +531,7 @@ int i, extension_size, max_elements;
 	}
 
 	if ( ((int)map->size - (int)sizeof(extension_map_t)) <= 0 ) {
-		printf("PANIC! - Verify map id %i: ERROR: map size %i too small!\n", map->map_id, map->size);
+		fprintf(stderr, "PANIC! - Verify map id %i: ERROR: map size %i too small!\n", map->map_id, map->size);
 		exit(255);
 	}
 
@@ -541,7 +541,7 @@ int i, extension_size, max_elements;
 	while (map->ex_id[i] && i <= max_elements) {
 		int id = map->ex_id[i];
 		if ( id > Max_num_extensions ) {
-			printf("PANIC! - Verify map id %i: ERROR: element id %i out of range [%i]!\n", map->map_id, id, Max_num_extensions);
+			fprintf(stderr, "PANIC! - Verify map id %i: ERROR: element id %i out of range [%i]!\n", map->map_id, id, Max_num_extensions);
 			exit(255);
 		}
 		extension_size += extension_descriptor[id].size;
@@ -558,7 +558,7 @@ int i, extension_size, max_elements;
 
 	if ( (i != max_elements ) && ((max_elements-i) != 1) ) {
 		// off by 1 is the opt alignment
-		printf("Verify map id %i: ERROR: Expected %i elements in map, but found %i!\n", map->map_id, max_elements, i);
+		fprintf(stderr, "Verify map id %i: ERROR: Expected %i elements in map, but found %i!\n", map->map_id, max_elements, i);
 	}
 
 } // End of FixExtensionMap


### PR DESCRIPTION
this will move all ERROR messages to stderr so they don't interfere with command line pipes or scripted parsers.