### PR TITLE
Added support for Cisco ZBF Source Security Group Extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,11 @@ NF9_NPROBE_SERVER_NW_DELAY_USEC | 57557
 NF9_NPROBE_APPL_LATENCY_SEC | 	57558
 NF9_NPROBE_APPL_LATENCY_USEC | 57559
 
+### Cisco ASR 1000 series NEL extension - Zone Based Firewall Logging__
+Tag | ID
+----|---
+NF9_ZBF_CTS_SRC_SGT  | 34000
+
 32 and 64 bit counters are supported for any counters. However, internally
 nfdump stores packets and bytes counters always as 64bit counters. 
 16 and 32 bit AS numbers are supported.

--- a/bin/netflow_v9.c
+++ b/bin/netflow_v9.c
@@ -349,6 +349,9 @@ static struct v9_element_map_s {
 	{ NF9_NPROBE_SERVER_NW_DELAY_SEC, 	 "NPROBE server lat sec",	_4bytes, _8bytes, move_slatency, nop, EX_LATENCY },
 	{ NF9_NPROBE_APPL_LATENCY_SEC, 	 	 "NPROBE appl lat sec",		_4bytes, _8bytes, move_slatency, nop, EX_LATENCY },
 
+    // Cisco ASR Zone Based Firewall Mapping
+	{ NF9_ZBF_CTS_SRC_SGT, 		"ASR source sgt",			_2bytes, _2bytes, move16, zero16, EX_ZBF_COMMON },
+
 	{0, "NULL",	0, 0}
 };
 
@@ -1079,6 +1082,9 @@ size_t				size_required;
 				break;
 			case EX_NEL_GLOBAL_IP_v4:
 				// XXX no longer used
+				break;
+			case EX_ZBF_COMMON:
+				PushSequence( table, NF9_ZBF_CTS_SRC_SGT, &offset, NULL, 0);
 				break;
 		}
 		extension_map->size += sizeof(uint16_t);

--- a/bin/netflow_v9.h
+++ b/bin/netflow_v9.h
@@ -315,6 +315,9 @@ typedef struct common_header_s {
 #define NF9_NPROBE_APPL_LATENCY_SEC		57558
 #define NF9_NPROBE_APPL_LATENCY_USEC	57559
 
+// Cisco ASR Zone Based Firewall
+#define NF9_ZBF_CTS_SRC_SGT  34000
+
 /* prototypes */
 int Init_v9(void);
 

--- a/bin/nffile.h
+++ b/bin/nffile.h
@@ -1128,6 +1128,17 @@ typedef struct tpl_ext_48_s {
 
 #define EX_NEL_RESERVED_1	49
 
+/*
+ * Cisco ZBR Block Allocation
+ * +----+--------------+--------------+
+ * |  0 | NF9_ZBF_CTS_SRC_SGT(34000)  |
+ * +----+--------------+--------------+
+ */
+#define EX_ZBF_COMMON 50
+typedef struct tpl_ext_50_s {
+	uint16_t	src_sgt;
+	uint8_t		data[4];	// points to further data
+} tpl_ext_50_t;
 
 /* 
  * 
@@ -1947,6 +1958,9 @@ typedef struct master_record_s {
 	// username
 #	define OffsetUsername  NSEL_BASE_OFFSET+10
 	char username[72];
+
+    // Cisco ASR ZBF extensions
+	uint16_t	src_sgt;
 
 	// NAT extensions
 	// NAT event is mapped into ASA event

--- a/bin/nffile_inline.c
+++ b/bin/nffile_inline.c
@@ -449,7 +449,12 @@ void		*p = (void *)input_record;
 					output_record->block_end = output_record->block_start + output_record->block_size - 1;
 				p = (void *)tpl->data;
 			} break;
-			
+			case EX_ZBF_COMMON: {
+				tpl_ext_50_t *tpl = (tpl_ext_50_t *)p;
+				output_record->src_sgt 	      = tpl->src_sgt;
+				p = (void *)tpl->data;
+			} break;
+
 #endif
 		}
 	}

--- a/bin/nfx.c
+++ b/bin/nfx.c
@@ -118,6 +118,9 @@ extension_descriptor_t extension_descriptor[] = {
 	{ EX_NEL_GLOBAL_IP_v4,  0,	0, 0,    	"Compat NEL IPv4"},
 	{ EX_PORT_BLOCK_ALLOC, 	8,	32, 0,    	"NAT Port Block Allocation"},
 	{ EX_NEL_RESERVED_1,	0,	0, 0,		NULL},
+	
+	// Cisco ARS  Zone Base Firewall Extensions
+	{ EX_ZBF_COMMON,	   2,	33, 0,		"ASR ZBF block"},
 
 	// last entry
 	{ 0,	0,	0, 0,	NULL }

--- a/bin/output_json.c
+++ b/bin/output_json.c
@@ -485,6 +485,11 @@ extension_map_t	*extension_map = r->map_ref;
 "	\"user_name\" : \"%s\",\n"
 , r->username[0] ? r->username : "<empty>");
 				break;
+			case EX_ZBF_COMMON:
+			    snprintf(_s, slen-1, 
+"	\"src_sgt\" : \"%u\",\n",  r->src_sgt);
+				break;
+
 #endif
 		}
 		_slen = strlen(data_string);

--- a/bin/output_raw.c
+++ b/bin/output_raw.c
@@ -550,6 +550,12 @@ extension_map_t	*extension_map = r->map_ref;
 				_s = data_string + _slen;
 				slen = STRINGSIZE - _slen;
 				break;
+			case EX_ZBF_COMMON:
+				snprintf(_s, slen-1,
+"  Source Security Group  =      %5u\n"
+, r->src_sgt);
+				break;
+
 #endif
 			default:
 				snprintf(_s, slen-1, "Type %u not implemented\n", id);


### PR DESCRIPTION
This request will add support for the Source Security Group extension within Cisco ASR routers. This is a part of the zone based firewall policy. 

https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_data_zbf/configuration/15-mt/sec-data-zbf-15-mt-book/sec-data-zbf-log.pdf

This closes #192.