### PR TITLE
Fix typo in nfdump.1

### DIFF
--- a/man/nfdump.1
+++ b/man/nfdump.1
@@ -1152,7 +1152,7 @@ To filter for netflow records with a specific number of aggregated flows.
 .I Type of Service (TOS)
 \fI[SourceDestination]\fR \fBtos <num>\fR
 .br
-With \fI<num>\fR 0..255. For compatibility with nfump 1.5.x:
+With \fI<num>\fR 0..255. For compatibility with nfdump 1.5.x:
 \fBtos <num>\fR is equivalent with \fBsrc tos <num>\fR
 .TP 4 
 .I Packets per second: Calculated value.


### PR DESCRIPTION
Reported to Debian BTS by Christoph Biedl, see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=909437