### PR TITLE
Fix crossbuilding by using AC_COMPILE_IFELSE instead of AC_RUN_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,7 @@ AC_SUBST(RRD_LIBS)
 	else
 		AC_MSG_ERROR(Required rrd.h header file not found!)
 	fi
-	AC_RUN_IFELSE(
+	AC_COMPILE_IFELSE(
 		[ AC_LANG_PROGRAM(
 			[[
 				#include <stdio.h>
@@ -202,7 +202,7 @@ AC_SUBST(RRD_LIBS)
 	else
 		AC_MSG_ERROR(Required rrd.h header file not found!)
 	fi
-	AC_RUN_IFELSE(
+	AC_COMPILE_IFELSE(
 		[ AC_LANG_PROGRAM(
 			[[
 				#include <stdio.h>
@@ -243,7 +243,7 @@ AC_SUBST(PCAP_LIBS)
 	else
 		AC_MSG_ERROR(Required pcap.h header file not found!)
 	fi
-	AC_RUN_IFELSE(
+	AC_COMPILE_IFELSE(
 		[ AC_LANG_PROGRAM(
 			[[
 				#include <stdio.h>


### PR DESCRIPTION
Fix crossbuilding by using AC_COMPILE_IFELSE instead of AC_RUN_IFELSE

Reported by Helmut Grohe on the Debian BTS at
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=948039
I have no idea about the merits of this patch, but Helmut is usually right