### PR TITLE
Allow processing of DLT_RAW links (i.e. for a tun VPN)

### DIFF
--- a/bin/pcaproc.c
+++ b/bin/pcaproc.c
@@ -449,7 +449,7 @@ pkt->vlans[pkt->vlan_count].pcp = (p[0] >> 5) & 7;
 					Free_Node(Node);
 					goto END_FUNC;
 			}
-	} else {
+	} else if ( pcap_dev->linktype != DLT_RAW ) { // we can still process raw IP
 		LogInfo("Unsupported link type: 0x%x, packet: %u", pcap_dev->linktype, pkg_cnt);
 		Free_Node(Node);
 		return;


### PR DESCRIPTION
I have a tun device running an openconnect VPN. 
The link type is DLT_RAW so it gets raw IP packets that can be process by nfpcapd with this modification. Shouldn't break anything.