### PR TITLE
Avoid use_syslog name clash

### DIFF
--- a/bin/util.c
+++ b/bin/util.c
@@ -118,12 +118,12 @@ void EndLog() {
 		closelog();
 } // End of CloseLog
 
-int InitLog(int use_syslog, char *name, char *facility, int verbose_log) {
+int InitLog(int want_syslog, char *name, char *facility, int verbose_log) {
 int i;
 char *logname;
 
 	verbose = verbose_log;
-	if ( !use_syslog ) 
+	if ( !want_syslog )
 		return 1;
 
 	if ( !facility || strlen(facility) > 32 ) {

--- a/bin/util.h
+++ b/bin/util.h
@@ -96,7 +96,7 @@ void xsleep(long sec);
 
 void EndLog(void);
 
-int InitLog(int use_syslog, char *name, char *facility, int verbose_log);
+int InitLog(int want_syslog, char *name, char *facility, int verbose_log);
 
 void LogError(char *format, ...);
 


### PR DESCRIPTION
This solves a conflict between the global `use_syslog` and the `use_syslog` argument. Due to this conflict, at least on my (embedded) system, the global use_syslog is not set correctly and syslog is not used.