### PR TITLE
fix plain numbers in statistics and summary

### DIFF
--- a/bin/nfdump.c
+++ b/bin/nfdump.c
@@ -803,7 +803,7 @@ char 		Ident[IDENTLEN];
 				byte_limit_string = optarg;
 				break;
 			case 'N':
-				printPlain = 1;
+				outputParams->printPlain = printPlain = 1;
 				break;
 			case 'f':
 				ffile = optarg;


### PR DESCRIPTION
This PR fix issue related to "Print plain numbers" mode (flag -N). Previously -N was not honored in statistics (flag -s) and summary.