### PR TITLE
bin: Use the libtool archives to link.

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -68,37 +68,31 @@ libnfdump_la_LDFLAGS = -release 1.6.22
 
 nfdump_SOURCES = nfdump.c nfdump.h nfstat.c nfstat.h nfexport.c nfexport.h  \
 	$(nflowcache) $(nfprof)
-nfdump_LDADD = -lnfdump
-nfdump_DEPENDENCIES = libnfdump.la
+nfdump_LDADD = libnfdump.la
 
 nfreplay_SOURCES = nfreplay.c $(nfprof) \
 	$(nfnet) $(collector) $(nfv1) $(nfv9) $(nfv5v7) $(ipfix)
-nfreplay_LDADD = -lnfdump
-nfreplay_DEPENDENCIES = libnfdump.la
+nfreplay_LDADD = libnfdump.la
 
 nfprofile_SOURCES = nfprofile.c profile.c profile.h $(nfstatfile) 
-nfprofile_LDADD = -lnfdump -lrrd
-nfprofile_DEPENDENCIES = libnfdump.la
+nfprofile_LDADD = libnfdump.la -lrrd
 
 nftrack_SOURCES = ../extra/nftrack/nftrack.c \
 	../extra/nftrack/nftrack_rrd.c ../extra/nftrack/nftrack_rrd.h \
 	../extra/nftrack/nftrack_stat.c ../extra/nftrack/nftrack_stat.h 
 nftrack_CFLAGS = -I ../extra/nftrack
-nftrack_LDADD = -lnfdump -lrrd
-nftrack_DEPENDENCIES = libnfdump.la
+nftrack_LDADD = libnfdump.la -lrrd
 
 nfcapd_SOURCES = nfcapd.c \
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(nfv1) $(nfv5v7) $(nfv9) $(ipfix) $(bookkeeper) $(expire)
-nfcapd_LDADD = -lnfdump 
-nfcapd_DEPENDENCIES = libnfdump.la
+nfcapd_LDADD = libnfdump.la
 
 nfpcapd_SOURCES = nfpcapd.c \
 	$(pcaproc) $(netflow_pcap) \
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(bookkeeper) $(expire) $(content)
-nfpcapd_LDADD = -lnfdump 
-nfpcapd_DEPENDENCIES = libnfdump.la
+nfpcapd_LDADD = libnfdump.la
 
 if READPCAP
 nfcapd_CFLAGS = -DPCAP
@@ -116,8 +110,7 @@ endif
 sfcapd_SOURCES = sfcapd.c sflow_nfdump.c sflow_nfdump.h sflow.h sflow_v2v4.h sflow_process.c  sflow_process.h\
 	$(nfstatfile) $(launch) \
 	$(nfnet) $(collector) $(bookkeeper) $(expire)
-sfcapd_LDADD = -lnfdump 
-sfcapd_DEPENDENCIES = libnfdump.la
+sfcapd_LDADD = libnfdump.la
 
 if READPCAP
 sfcapd_CFLAGS = -DPCAP
@@ -126,32 +119,27 @@ sfcapd_LDADD += -lpcap
 endif
 
 nfreader_SOURCES = nfreader.c 
-nfreader_LDADD = -lnfdump 
-nfreader_DEPENDENCIES = libnfdump.la
+nfreader_LDADD = libnfdump.la
 
 nfanon_SOURCES = nfanon.c $(anon)
-nfanon_LDADD = -lnfdump 
-nfanon_DEPENDENCIES = libnfdump.la
+nfanon_LDADD = libnfdump.la
 
 nfgen_SOURCES = nfgen.c 
-nfgen_LDADD = -lnfdump 
-nfgen_DEPENDENCIES = libnfdump.la
+nfgen_LDADD = libnfdump.la
 
 nfexpire_SOURCES = nfexpire.c \
 	$(bookkeeper) $(expire) $(nfstatfile)
-nfexpire_LDADD = -lnfdump @FTS_OBJ@
-nfexpire_DEPENDENCIES = libnfdump.la
+nfexpire_LDADD = libnfdump.la @FTS_OBJ@
 
 nftest_SOURCES = nftest.c 
-nftest_LDADD = -lnfdump 
-nftest_DEPENDENCIES = nfgen libnfdump.la
+nftest_LDADD = libnfdump.la
+nftest_DEPENDENCIES = nfgen
 
 if FT2NFDUMP
 ft2nfdump_SOURCES = ft2nfdump.c 
 ft2nfdump_CFLAGS = @FT_INCLUDES@
-ft2nfdump_LDADD = -lnfdump -lft -lz
+ft2nfdump_LDADD = libnfdump.la -lft -lz
 ft2nfdump_LDADD += @FT_LDFLAGS@
-ft2nfdump_DEPENDENCIES = libnfdump.la
 endif
 
 check_DIST = inline.c collector_inline.c nffile_inline.c nfdump_inline.c heapsort_inline.c applybits_inline.c 


### PR DESCRIPTION
When building nfdump with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CC --mode=link clang -g -O3 -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wmissing-noreturn -fno-strict-aliasing -o nfcapd nfcapd-nfcapd.o nfcapd-nfstatfile.o nfcapd-launch.o nfcapd-nfnet.o nfcapd-collector.o nfcapd-netflow_v1.o nfcapd-netflow_v5_v7.o nfcapd-netflow_v9.o nfcapd-ipfix.o nfcapd-bookkeeper.o nfcapd-expire.o -lnfdump -lresolv -lbz2

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/nfdump/bin"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 34, .st_ino = 19180}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 34, .st_ino = 19109}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/nfdump/libtool".
rdlibtool: link: clang nfcapd-nfcapd.o nfcapd-nfstatfile.o nfcapd-launch.o nfcapd-nfnet.o nfcapd-collector.o nfcapd-netflow_v1.o nfcapd-netflow_v5_v7.o nfcapd-netflow_v9.o nfcapd-ipfix.o nfcapd-bookkeeper.o nfcapd-expire.o -g -O3 -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wmissing-noreturn -fno-strict-aliasing -lnfdump -lresolv -lbz2 -o .libs/nfcapd
/usr/bin/ld: cannot find -lnfdump
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
rdlibtool: exec error upon slbt_exec_link_create_executable(), line 1614: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1934.
make[2]: *** [Makefile:985: nfcapd] Error 2
make[2]: Leaving directory '/tmp/nfdump/bin'
make[1]: *** [Makefile:1972: install] Error 2
make[1]: Leaving directory '/tmp/nfdump/bin'
make: *** [Makefile:410: install-recursive] Error 1
```
This is because `LDADD` should use the libtool archive directly (`.la`) rather than being placed in `DEPENDENCIES` and not use the `-lnfdump` linker flag which should be reserved for external dependencies. GNU libtool does not complain because it is far more permissive.