### PR TITLE
Makefile.am: add ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = . bin man doc
 


### PR DESCRIPTION
Per autoconf docs [0], if using automake and AC_CONFIG_MACRO_DIR,
we need to include ACLOCAL_AMFLAGS in Makefile.am.

So, let's set ACLOCAL_AMFLAGS = -I m4.

This sorts out an automake warning.

Signed-off-by: Sam James <sam@gentoo.org>