### PR TITLE
Fix build error on Debian 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ if test "${enable_fixtimebug}" = "yes" ; then
 fi
 
 AC_PROG_YACC
-AC_PROG_LEX(yywrap)
+AC_PROG_LEX(noyywrap)
 which $LEX > /dev/null 2>&1
 if test $? = 1; then
 	AC_MSG_ERROR(No lex or flex found on system)


### PR DESCRIPTION
This backports the lex change (from da6f37f6abb0cab0cefd6888ebda8e92f0f8903a in the 1.7 series) to 1.6. It is necessary to build on Debian Bookworm.