### PR TITLE
Use ChangeLog mtime as VCS_TRACK_DATE

### DIFF
--- a/src/lib/gen_version.sh
+++ b/src/lib/gen_version.sh
@@ -28,7 +28,7 @@
 
 echo Creating vcs_track.h
 f="vcs_track.h"
-date=$(date +'%c')
+date=$(date -r ../../configure.ac +'%c')
 
 if [ -d ../../.git ]; then
   # git clone - should have git command too


### PR DESCRIPTION
without this patch, builds from release tarballs varied between builds in `/usr/lib64/libnfdump-1.7.3.so`.

See https://reproducible-builds.org/ for why this matters.

Alternatives are:
* drop `VCS_TRACK_DATE`
* allow to use [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) to override

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).