### PR TITLE
Bugfix for nfdump issue #486.

### DIFF
--- a/src/sflow/sflow_process.c
+++ b/src/sflow/sflow_process.c
@@ -1948,11 +1948,9 @@ static void readExtendedProxySocket6(SFSample *sample) {
 */
 
 static void readExtendedDecap(SFSample *sample, char *prefix) {
-#ifdef DEVEL
     uint32_t offset = getData32(sample);
     dbg_printf("extendedType %sdecap\n", prefix);
     dbg_printf("%sdecap_inner_header_offset %u\n", prefix, offset);
-#endif
 }
 
 /*_________________----------------------------__________________
@@ -1961,11 +1959,9 @@ static void readExtendedDecap(SFSample *sample, char *prefix) {
 */
 
 static void readExtendedVNI(SFSample *sample, char *prefix) {
-#ifdef DEVEL
     uint32_t vni = getData32(sample);
     dbg_printf("extendedType %sVNI\n", prefix);
     dbg_printf("%sVNI %u\n", prefix, vni);
-#endif
 }
 
 /*_________________----------------------------__________________


### PR DESCRIPTION
Fixed issue where sfcapd will only write flows from samples containing VNI data when compiled with --enable-devel.

Additionally, it appears the same issue would occur with the readExtendedDecap, so that has been adjusted as well.