### PR TITLE
Don't clear flowStartMilliseconds when flowEndMilliseconds==0

### DIFF
--- a/src/inline/nffile_inline.c
+++ b/src/inline/nffile_inline.c
@@ -470,7 +470,7 @@ static inline void ExpandRecord_v3(recordHeaderV3_t *v3Record, master_record_t *
 
 #ifdef NSEL
     if (output_record->msecFirst == 0) output_record->msecFirst = output_record->msecEvent;
-    if (output_record->msecLast == 0) output_record->msecFirst = output_record->msecEvent;
+    if (output_record->msecLast == 0) output_record->msecLast = output_record->msecEvent;
 #endif
 
 #ifdef DEVEL


### PR DESCRIPTION
This is a trivial bug introduced in
222419364892155de294792a262cca5e27d41993