### PR TITLE
enable bgpnext ip syntax

### DIFF
--- a/src/libnfdump/filter/grammar.y
+++ b/src/libnfdump/filter/grammar.y
@@ -173,7 +173,7 @@ static int AddASList(direction_t direction, void *U64List);
 %token EQ LT GT LE GE
 %token ANY NOT IDENT COUNT
 %token IP IPV4 IPV6 NET
-%token SRC DST IN OUT PREV NEXT BGP ROUTER INGRESS EGRESS
+%token SRC DST IN OUT PREV NEXT BGP BGPNEXT ROUTER INGRESS EGRESS
 %token NAT XLATE TUN
 %token ENGINE ENGINETYPE ENGINEID EXPORTER
 %token DURATION PPS BPS BPP FLAGS
@@ -533,6 +533,7 @@ dqual:	 { $$.direction = DIR_UNSPEC;   }
 	| EGRESS	 { $$.direction = DIR_EGRESS;   }
 	| PREV		 { $$.direction = DIR_PREV;     }
 	| NEXT		 { $$.direction = DIR_NEXT;     }
+	| BGPNEXT	 { $$.direction = BGP_NEXT;	}
 	| BGP NEXT       { $$.direction = BGP_NEXT;	}
 	| ROUTER	 { $$.direction = SRC_ROUTER;   }
 	| EXPORTER       { $$.direction = SRC_ROUTER;   }
@@ -717,7 +718,7 @@ static int AddProto(direction_t direction, char *protoStr, uint64_t protoNum) {
 	  	yyerror("Unknown protocol specifier");
 			return -1;
 	}
-} // End of AddProtoString
+} // End of AddProto
 
 static int AddEngineNum(char *type, uint16_t comp, uint64_t num) {
 	if ( num > 255 ) {

--- a/src/libnfdump/filter/scanner.l
+++ b/src/libnfdump/filter/scanner.l
@@ -134,6 +134,7 @@ out				{ return OUT;    }
 next			{ return NEXT;   }
 prev			{ return PREV;   }
 bgp				{ return BGP;    }
+bgpnext		{ return BGPNEXT; }
 router		{ return ROUTER; }
 nat		    { return NAT;    }
 xlate		  { return NAT;    }


### PR DESCRIPTION
Currently `bgpnext ip ...` syntax is not allowed. Instead `bgp next ip ...` should be used but it is undocumented. This PR allows use old syntax `bgpnext ip ...` in similar way as icmp-type/icmp-code/engine-type/engine-id.