### PR TITLE
fixed updateTorDB.sh

### DIFF
--- a/src/tor/updateTorDB.sh
+++ b/src/tor/updateTorDB.sh
@@ -31,7 +31,7 @@ fetch_files() {
 	n=$(($1 - 1))
 	current_year=$(date +"%Y")
 	current_month=$(date +"%m")
-	for i in $(seq $n 0); do
+	for i in $(seq $n -1 0); do
 		# Add #0 to prevent '08' for month August to be interpreted octal and fail due to value too great for base
 		month=$((${current_month#0} - $i))
 		year=$current_year


### PR DESCRIPTION
Hi,

The script was only able to download data for one month using ./updateTorDB.sh 1. Any attempt to specify a higher value failed because the backward counting mechanism was broken. The issue was due to a missing `-1` in the sequence loop. It needed to be changed from:
`$(seq $n 0)`
to
`$(seq $n -1 0)`

BR
Takalele
