### PR TITLE
GRE tunnel introspection for sFlow

### DIFF
--- a/src/sflow/sflow_nfdump.c
+++ b/src/sflow/sflow_nfdump.c
@@ -147,8 +147,8 @@ int Init_sflow(int verbose, char *extensionList) {
 }  // End of Init_sflow
 
 // called by sfcapd for each packet
-void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs) {
-    SFSample sample = {.rawSample = in_buff, .rawSampleLen = in_buff_cnt, .sourceIP.s_addr = fs->sa_family == PF_INET ? htonl(fs->ip.V4) : 0};
+void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs, int parse_gre) {
+    SFSample sample = {.rawSample = in_buff, .rawSampleLen = in_buff_cnt, .sourceIP.s_addr = fs->sa_family == PF_INET ? htonl(fs->ip.V4) : 0, .parse_gre = parse_gre};
 
     dbg_printf("startDatagram =================================\n");
     // catch SFABORT in sflow code

--- a/src/sflow/sflow_nfdump.h
+++ b/src/sflow/sflow_nfdump.h
@@ -39,7 +39,7 @@
 
 int Init_sflow(int verbose, char *extensionList);
 
-void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs);
+void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs, int parse_gre);
 
 void StoreSflowRecord(SFSample *sample, FlowSource_t *fs);
 

--- a/src/sflow/sflow_process.c
+++ b/src/sflow/sflow_process.c
@@ -688,7 +688,7 @@ static void decodeIPLayer4(SFSample *sample, uint8_t *ptr) {
             sample->offsetToPayload = ptr + sizeof(udp) - sample->header;
         } break;
         case 47: { /* GRE */
-            dbg_printf("GRE");
+            dbg_printf("GRE\n");
             if (sample->parse_gre) {
                 struct mygreheader gre;
                 memcpy(&gre, ptr, sizeof(gre));
@@ -713,8 +713,8 @@ static void decodeIPLayer4(SFSample *sample, uint8_t *ptr) {
                     }
                 }
                 dbg_printf("GRE: Header type: %u\n", sample->headerProtocol);
-                sample->datap = sample->headerDescriptionStart; // Reset
-                sample->header = ptr + gre_header_length; // Start parsing header after GRE payload
+                sample->datap = sample->headerDescriptionStart; /* Reset parsing pointer for metadata */
+                sample->header = ptr + gre_header_length; /* Set parsing pointer for header to end of GRE header */
                 readFlowSample_header(sample);
                 return;
             }

--- a/src/sflow/sflow_process.h
+++ b/src/sflow/sflow_process.h
@@ -106,6 +106,13 @@ struct myicmphdr {
                   /* ignore the rest */
 };
 
+/* and GRE (RFC 2890) */
+struct mygreheader { /* only relevant fields */
+    uint8_t flags; /* presence indicators for checksum, key, and sequence number */
+    uint8_t version; /* GRE version */
+    uint16_t protocol_type; /* EtherType code for encapsulated protocol */
+};
+
 typedef struct _SFSample {
     /* exception handler context */
     jmp_buf env;
@@ -149,6 +156,7 @@ typedef struct _SFSample {
     uint8_t *header;
     uint32_t headerLen;
     uint32_t stripped;
+    uint32_t *headerDescriptionStart;
 
     /* header decode */
     int gotIPV4;
@@ -270,6 +278,8 @@ typedef struct _SFSample {
 #define SF_ABORT_EOS 1
 #define SF_ABORT_DECODE_ERROR 2
 #define SF_ABORT_LENGTH_ERROR 3
+
+    int parse_gre;
 
 } SFSample;
 


### PR DESCRIPTION
### Background

[Generic Routing Encapsulation (GRE)](https://en.wikipedia.org/wiki/Generic_Routing_Encapsulation) is a tunneling protocol that allows to encapsulate data of various protocols (most prominently Ethernet and IP) in IP packets. For example, an Ethernet frame encapsulated in an IP packet would lead to the following overall header structure:
```
Outer Ethernet header | Outer IP header | GRE header | Encapsulated Ethernet frame
```
Alternatively, it is also possible to encapsulate pure IP packets only, using the following header structure:
```
Outer Ethernet header | Outer IP header | GRE header | Encapsulated IP packet
```

Most relevantly, the GRE header includes a field for the protocol type of the encapsulated protocol, which uses the [EtherType](https://en.wikipedia.org/wiki/EtherType) codes.

Naturally, multiple GRE layers can be nested.

### Problem

Currently, the header parsing for sFlow considers GRE a blackbox layer-4 protocol, only parses the outer headers, and records the corresponding flow information. For demonstration, we provide a [PCAP file](https://github.com/NetFabric-AI/netfabric-public/blob/main/pcaps/tunnel_sflow.pcap), containing sFlow records for 5 different flows that are encapsulated in an IP flow from `1.1.1.1` to `2.2.2.2`. When recording these packets with `sfcapd`, `nfdump` shows the following records:
```
Date first seen         Duration         Proto      Src IP Addr:Port          Dst IP Addr:Port   Packets    Bytes Flows
2024-08-23 13:28:37.113     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       84     1
2024-08-23 13:28:37.113     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       70     1
2024-08-23 13:28:37.113     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       90     1
2024-08-23 13:28:37.113     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1      106     1
2024-08-23 13:28:37.113     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       42     1
```

 However, in many scenarios where GRE tunneling is applied, the interesting flow information might be in the _encapsulated_ packet.

### Solution approach

We added a new command-line option `-G` to signal that `sfcapd` should consider the GRE-encapsulated packet relevant for extracting flow information. Whenever the `-G` flag is present and `sfcapd` encounters a GRE header (i.e., in `sflow_process.c`), the parsing restarts _after_ the GRE header. This logic is applied recursively, i.e., always the 'innermost' packet is relevant for flow information.

### Result & Tests

When feeding [the same sFlow records](https://github.com/NetFabric-AI/netfabric-public/blob/main/pcaps/tunnel_sflow.pcap) as above to `sfcapd` with GRE parsing enabled, we observe the following `nfdump` output, making the tunneled flows visible:
```
Date first seen         Duration         Proto      Src IP Addr:Port          Dst IP Addr:Port   Packets    Bytes Flows
2024-08-23 13:49:27.054     00:00:00.000 UDP            3.3.3.3:53    ->          4.4.4.4:53           1       84     1
2024-08-23 13:49:27.054     00:00:00.000 UDP            5.5.5.5:53    ->          6.6.6.6:53           1       70     1
2024-08-23 13:49:27.054     00:00:00.000 UDP    7:7:7:7:7:7:7:7.53    ->  8:8:8:8:8:8:8:8.53           1       90     1
2024-08-23 13:49:27.054     00:00:00.000 UDP        11.11.11.11:53    ->      12.12.12.12:53           1      106     1
2024-08-23 13:49:27.054     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       42     1
```
The last flow record with protocol GRE refers to a packet where the GRE header is not followed by any encapsulated packet (added for robustness checks).

Moreover, all tests run with `make check` still pass.

### Contributors

This pull request is proposed by Simon Scherrer from [NetFabric.ai](https://netfabric.ai/).