### PR TITLE
sFlow for tunnels: Tunnel extension & IPv6 encapsulation support

### DIFF
--- a/src/sflow/sfcapd.c
+++ b/src/sflow/sfcapd.c
@@ -96,7 +96,7 @@ static int verbose = 0;
 typedef ssize_t (*packet_function_t)(int, void *, size_t, int, struct sockaddr *, socklen_t *);
 
 static option_t sfcapdConfig[] = {
-    {.name = "gre", .valBool = 0, .flags = OPTDEFAULT}, {.name = "maxworkers", .valUint64 = 2, .flags = OPTDEFAULT}, {.name = NULL}};
+    {.name = "gre", .valBool = 0, .flags = OPTDEFAULT}, {.name = "6in4", .valBool = 0, .flags = OPTDEFAULT}, {.name = "maxworkers", .valUint64 = 2, .flags = OPTDEFAULT}, {.name = NULL}};
 
 /* module limited globals */
 static FlowSource_t *FlowSource;
@@ -115,7 +115,7 @@ static void IntHandler(int signal);
 static inline FlowSource_t *GetFlowSource(struct sockaddr_storage *ss);
 
 static void run(packet_function_t receive_packet, int socket, int pfd, int rfd, time_t twin, time_t t_begin, char *time_extension, int compress,
-                int parse_gre);
+                int parse_gre, int parse_6in4);
 
 /* Functions */
 static void usage(char *name) {
@@ -140,7 +140,7 @@ static void usage(char *name) {
         "-i interval\tMetric interval in s for metric exporter\n"
         "-m socket\t\tEnable metric exporter on socket.\n"
         "-M dir \t\tSet the output directory for dynamic sources.\n"
-        "-o options \tAdd sfcpad options, separated with ','. Available: 'gre'\n"
+        "-o options \tAdd sfcpad options, separated with ','. Available: 'gre', '6in4'\n"
         "-P pidfile\tset the PID file\n"
         "-R IP[/port]\tRepeat incoming packets to IP address/port. Max 8 repeaters.\n"
         "-A\t\tEnable source address spoofing for packet repeater -R.\n"
@@ -272,7 +272,7 @@ static int SendRepeaterMessage(int fd, void *in_buff, size_t cnt, struct sockadd
 }  // End of SendRepeaterMessage
 
 static void run(packet_function_t receive_packet, int socket, int pfd, int rfd, time_t twin, time_t t_begin, char *time_extension, int compress,
-                int parse_gre) {
+                int parse_gre, int parse_6in4) {
     struct sockaddr_storage sf_sender;
     socklen_t sf_sender_size = sizeof(sf_sender);
 
@@ -430,7 +430,7 @@ static void run(packet_function_t receive_packet, int socket, int pfd, int rfd, 
 
         fs->received = tv;
         /* Process data - have a look at the common header */
-        Process_sflow(in_buff, cnt, fs, parse_gre);
+        Process_sflow(in_buff, cnt, fs, parse_gre, parse_6in4);
 
         // each Process_xx function has to process the entire input buffer, therefore it's empty
         // now.
@@ -458,7 +458,7 @@ int main(int argc, char **argv) {
     FlowSource_t *fs;
     int family, bufflen, metricInterval;
     time_t twin;
-    int sock, do_daemonize, expire, spec_time_extension, parse_gre;
+    int sock, do_daemonize, expire, spec_time_extension, parse_gre, parse_6in4;
     int subdir_index, compress, srcSpoofing;
     uint64_t workers;
 #ifdef PCAP
@@ -495,6 +495,7 @@ int main(int argc, char **argv) {
     options = NULL;
     workers = 0;
     parse_gre = 0;
+    parse_6in4 = 0;
 
     int c;
     while ((c = getopt(argc, argv, "46AB:b:C:d:DeEf:g:hI:i:jJ:l:m:M:n:o:p:P:R:S:T:t:u:vVW:w:x:X:yz::Z:")) != EOF) {
@@ -786,6 +787,7 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
     OptGetBool(sfcapdConfig, "gre", &parse_gre);
+    OptGetBool(sfcapdConfig, "6in4", &parse_6in4);
 
     if (datadir && !AddFlowSource(&FlowSource, Ident, ANYIP, datadir)) {
         LogError("Failed to add default data collector directory");
@@ -920,7 +922,7 @@ int main(int argc, char **argv) {
     sigaction(SIGPIPE, &act, NULL);
 
     LogInfo("Startup sfcapd.");
-    run(receive_packet, sock, pfd, rfd, twin, t_start, time_extension, compress, parse_gre);
+    run(receive_packet, sock, pfd, rfd, twin, t_start, time_extension, compress, parse_gre, parse_6in4);
 
     // shutdown
     close(sock);

--- a/src/sflow/sflow_nfdump.c
+++ b/src/sflow/sflow_nfdump.c
@@ -302,7 +302,7 @@ void StoreSflowRecord(SFSample *sample, FlowSource_t *fs) {
         recordSize += EXipReceivedV6Size;
     }
 
-    // GRE tunnels
+    // Tunnels
     int tun_isV4 = sample->tun_ipsrc.type == SFLADDRESSTYPE_IP_V4;
     if (tun_isV4 && ExtensionsEnabled[EXtunIPv4ID]) {
         recordSize += EXtunIPv4Size;
@@ -472,7 +472,7 @@ void StoreSflowRecord(SFSample *sample, FlowSource_t *fs) {
         dbg_printf("Add IPv6 route IP extension\n");
     }
 
-    // GRE tunnels
+    // Tunnels
     if (tun_isV4 && ExtensionsEnabled[EXtunIPv4ID]) {
         PushExtension(recordHeader, EXtunIPv4, tunIPv4);
         tunIPv4->tunSrcAddr = ntohl(sample->tun_ipsrc.address.ip_v4.addr);
@@ -497,6 +497,7 @@ void StoreSflowRecord(SFSample *sample, FlowSource_t *fs) {
         tunIPv6->tunDstAddr[1] = ntohll(*u);
 
         tunIPv6->tunProto = sample->tun_proto;
+        dbg_printf("Add IPv6 tunnel extension\n");
     }
 
 

--- a/src/sflow/sflow_nfdump.h
+++ b/src/sflow/sflow_nfdump.h
@@ -39,7 +39,7 @@
 
 int Init_sflow(int verbose, char *extensionList);
 
-void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs, int parse_gre);
+void Process_sflow(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs, int parse_gre, int parse_6in4);
 
 void StoreSflowRecord(SFSample *sample, FlowSource_t *fs);
 

--- a/src/sflow/sflow_process.h
+++ b/src/sflow/sflow_process.h
@@ -279,7 +279,7 @@ typedef struct _SFSample {
 #define SF_ABORT_DECODE_ERROR 2
 #define SF_ABORT_LENGTH_ERROR 3
 
-    /* GRE tunnels */
+    /* tunnels */
     int parse_gre;  /* Enable GRE tunnel introspection */
     int parse_6in4; /* Enable 6in4 tunnel introspection */
     SFLAddress tun_ipsrc;

--- a/src/sflow/sflow_process.h
+++ b/src/sflow/sflow_process.h
@@ -279,7 +279,13 @@ typedef struct _SFSample {
 #define SF_ABORT_DECODE_ERROR 2
 #define SF_ABORT_LENGTH_ERROR 3
 
-    int parse_gre;
+    /* GRE tunnels */
+    int parse_gre;  /* Enable GRE tunnel introspection */
+    int parse_6in4; /* Enable 6in4 tunnel introspection */
+    SFLAddress tun_ipsrc;
+    SFLAddress tun_ipdst;
+    uint32_t tun_proto;
+
 
 } SFSample;
 


### PR DESCRIPTION
Hi Peter, we have another suggestion for tunneling support in sFlow, building on our previous pull request.

Let us know what you think! :)

### Background

Motivated by pull request #559, `sfcapd` was recently extended with the capability to parse the nested headers used in GRE tunnels. Given the new command-line option  `-o gre`, `sfcapd` will consider the _innermost_ header stack (i.e., the _tunneled_ flow) to be relevant for the stored flow information. In absence of that command-line option, the _outermost_ header stack (i.e., the _tunneling_ flow) is considered critical.

### Problem

While being a valuable first step, previous `sfcapd` tunnel functionality would benefit from the following two extensions:

- **Complete tunnel information:** The current command-line option forces the user to choose between analyzing the tunneled flow and analyzing the tunneling flow. However, it is often interesting to know which tunnels encapsulated which flows, and thus to store the combination of the tunneling flow and tunneled flow.
- **IPv6 encapsulation support:** To tunnel IPv6 traffic in IPv4 traffic, using GRE for tunneling is actually unnecessary, as IPv6 encapsulation (IP protocol number 41, e.g. 6to4 and 6in4) allows to simply concatenate an IPv4 header and an IPv6 header (without intermediate GRE header). Since such encapsulation tunnels might thus appear frequently in practice, `sfcapd` support for such IPv6 encapsulation would be desirable.

### Solution approach

We implement the extensions mentioned above as follows:

- **Complete tunnel information:** The information from the outermost IP header is stored in the already existing tunnel extension, which was already suggested in the discussion of pull request #559.
- **IPv6 encapsulation support:** Upon discovery of an IP header with protocol number 41, the header parsing is restarted recursively after that header - analogously to the parsing behavior upon discovery of a GRE header. The user can now use the option `6in4` (i.e., with `-o 6in4`) to convey that the parsing should advance beyond encapsulation headers.

### Result & Tests  

For demonstations, we provide a [PCAP file](https://github.com/NetFabric-AI/netfabric-public/blob/main/pcaps/tunnel_sflow.pcap) (extended with a 6in4 flow compared to pull request #559), containing sFlow records for 6 different flows that are encapsulated in an IP flow from 1.1.1.1 to 2.2.2.2. When recording these packets with `sfcapd` using `-o gre,6in4` , `nfdump` now shows the following records:
```
Date first seen         Duration         Proto      Src IP Addr:Port          Dst IP Addr:Port   Packets    Bytes Flows
2024-11-01 16:24:19.768     00:00:00.000 GRE            1.1.1.1:53    ->          2.2.2.2:53           1       84     1
2024-11-01 16:24:19.768     00:00:00.000 UDP            3.3.3.3:53    ->          4.4.4.4:53           1       84     1
2024-11-01 16:24:19.768     00:00:00.000 GRE            1.1.1.1:53    ->          2.2.2.2:53           1       70     1
2024-11-01 16:24:19.768     00:00:00.000 UDP            5.5.5.5:53    ->          6.6.6.6:53           1       70     1
2024-11-01 16:24:19.768     00:00:00.000 GRE            1.1.1.1:53    ->          2.2.2.2:53           1       90     1
2024-11-01 16:24:19.768     00:00:00.000 UDP    7:7:7:7:7:7:7:7.53    ->  8:8:8:8:8:8:8:8.53           1       90     1
2024-11-01 16:24:19.768     00:00:00.000 GRE            1.1.1.1:53    ->          2.2.2.2:53           1      106     1
2024-11-01 16:24:19.768     00:00:00.000 UDP        11.11.11.11:53    ->      12.12.12.12:53           1      106     1
2024-11-01 16:24:19.768     00:00:00.000 GRE            1.1.1.1:0     ->          2.2.2.2:0            1       42     1
2024-11-01 16:24:19.768     00:00:00.000 IPv6           1.1.1.1:53    ->          2.2.2.2:53           1       86     1
2024-11-01 16:24:19.768     00:00:00.000 UDP   13:13:1..3:13:13.53    -> 14:14:1..4:14:14.53           1       86     1
```
(The third-to-last flow record comes from a pathological packet with an empty GRE payload).

Moreover, all tests run with `make check` still pass.

### Contributors

This pull request is proposed by Simon Scherrer from [NetFabric.ai](https://netfabric.ai/).