### PR TITLE
Update nfdump.1

### DIFF
--- a/man/nfdump.1
+++ b/man/nfdump.1
@@ -143,8 +143,8 @@ Read more options from file
 .Ar config.
 .Nm
 tries to read by default
-.Ar %prefix/etc/nfdump.config.
-This may be overwritten by the environment valiable
+.Ar %prefix/etc/nfdump.conf.
+This may be overwritten by the environment variable
 .Ar NFCONF
 which again may be overwritten by this option
 .Fl C.


### PR DESCRIPTION
Typos: "nfdump tries to read by default %prefix/etc/nfdump.conf" instead of "nfdump.config")