### PR TITLE
Fix wrong SSL 2.0 version and remove SSL 1.0 (bug in older JA4 spec)

### DIFF
--- a/src/libnfdump/filter/grammar.y
+++ b/src/libnfdump/filter/grammar.y
@@ -1304,7 +1304,7 @@ static int AddPayloadSSL(char *type, char *arg, char *opt) {
 			yyprintf("String %s is not a valid SSL/TLS version", opt);
 			return -1;
 		}
-		// if old SSL 1.0, 2.0 or 3.0
+		// if old SSL 2.0 or 3.0
 		if (major > 1 && minor > 0){
 			yyprintf("String %s is not a valid SSL/TLS version", opt);
 			return -1;

--- a/src/libnfdump/ssl/ssl.c
+++ b/src/libnfdump/ssl/ssl.c
@@ -250,19 +250,13 @@ static int sslParseClientHandshake(ssl_t *ssl, BytesStream_t sslStream, uint32_t
     0x0302 = TLS 1.1 = “11”
     0x0301 = TLS 1.0 = “10”
     0x0300 = SSL 3.0 = “s3”
-    0x0200 = SSL 2.0 = “s2”
-    0x0100 = SSL 1.0 = “s1”
+    0x0002 = SSL 2.0 = “s2”
 
     Unknown = “00”
     */
     ssl->protocolVersion = version;
     switch (version) {
-        case 0x0100:
-            // SSL 1.0 was never really release!
-            ssl->tlsCharVersion[0] = 's';
-            ssl->tlsCharVersion[1] = '1';
-            break;
-        case 0x0200:  // SSL 2.0
+        case 0x0002:  // SSL 2.0
             ssl->tlsCharVersion[0] = 's';
             ssl->tlsCharVersion[1] = '2';
             break;
@@ -287,8 +281,8 @@ static int sslParseClientHandshake(ssl_t *ssl, BytesStream_t sslStream, uint32_t
             ssl->tlsCharVersion[1] = '3';
             break;
         default:
-            LogError("%s():%d Not an SSL 3.0 - TLS 1.3 protocol", __FUNCTION__, __LINE__);
-            dbg_printf("Client handshake: Not an SSL 3.0 - TLS 1.3 protocol\n");
+            LogError("%s():%d Not an SSL 2.0 - TLS 1.3 protocol", __FUNCTION__, __LINE__);
+            dbg_printf("Client handshake: Not an SSL 2.0 - TLS 1.3 protocol\n");
             return 0;
     }
 
@@ -347,10 +341,7 @@ static int sslParseServerHandshake(ssl_t *ssl, BytesStream_t sslStream, uint32_t
 
     ssl->protocolVersion = version;
     switch (version) {
-        case 0x0100:
-            // SSL 1.0 was never really release!
-            break;
-        case 0x0200:  // SSL 2.0
+        case 0x0002:  // SSL 2.0
             ssl->tlsCharVersion[0] = 's';
             ssl->tlsCharVersion[1] = '2';
             break;
@@ -371,8 +362,8 @@ static int sslParseServerHandshake(ssl_t *ssl, BytesStream_t sslStream, uint32_t
             ssl->tlsCharVersion[1] = '3';
             break;
         default:
-            LogError("%s():%d Not an SSL 3.0 - TLS 1.3 protocol", __FUNCTION__, __LINE__);
-            dbg_printf("Client handshake: Not an SSL 3.0 - TLS 1.3 protocol\n");
+            LogError("%s():%d Not an SSL 2.0 - TLS 1.3 protocol", __FUNCTION__, __LINE__);
+            dbg_printf("Client handshake: Not an SSL 2.0 - TLS 1.3 protocol\n");
             return 0;
     }
 
@@ -516,14 +507,14 @@ ssl_t *sslProcess(const uint8_t *data, size_t len) {
     uint16_t sslVersion;
     ByteStream_GET_u16(sslStream, sslVersion);
     switch (sslVersion) {
-        case 0x0200:  // SSL 2.0
+        case 0x0002:  // SSL 2.0
         case 0x0300:  // SSL 3.0
         case 0x0301:  // TLS 1.1
         case 0x0302:  // TLS 1.2
         case 0x0303:  // TLS 1.3
             break;
         default:
-            dbg_printf("SSL version: 0x%x not SSL 3.0 - TLS 1.3 connection\n", sslVersion);
+            dbg_printf("SSL version: 0x%x not SSL 2.0 - TLS 1.3 connection\n", sslVersion);
             return NULL;
     }
 

--- a/src/libnfdump/ssl/ssl.h
+++ b/src/libnfdump/ssl/ssl.h
@@ -81,8 +81,7 @@ typedef struct ssl_s {
         0x0302 = TLS 1.1 = “11”
         0x0301 = TLS 1.0 = “10”
         0x0300 = SSL 3.0 = “s3”
-        0x0200 = SSL 2.0 = “s2”
-        0x0100 = SSL 1.0 = “s1”
+        0x0002 = SSL 2.0 = “s2”
         Unknown = “00”
      */
 

--- a/src/output/output_csv.c
+++ b/src/output/output_csv.c
@@ -1161,8 +1161,7 @@ static char *String_tlsVersion(char *streamPtr, recordHandle_t *recordHandle) {
     0x0302 = TLS 1.1 = “11”
     0x0301 = TLS 1.0 = “10”
     0x0300 = SSL 3.0 = “s3”
-    0x0200 = SSL 2.0 = “s2”
-    0x0100 = SSL 1.0 = “s1”
+    0x0002 = SSL 2.0 = “s2”
     */
 
     // ssl is defined

--- a/src/output/output_fmt.c
+++ b/src/output/output_fmt.c
@@ -1212,8 +1212,7 @@ static void String_tlsVersion(FILE *stream, recordHandle_t *recordHandle) {
     0x0302 = TLS 1.1 = “11”
     0x0301 = TLS 1.0 = “10”
     0x0300 = SSL 3.0 = “s3”
-    0x0200 = SSL 2.0 = “s2”
-    0x0100 = SSL 1.0 = “s1”
+    0x0002 = SSL 2.0 = “s2”
     */
 
     // ssl is defined


### PR DESCRIPTION
Fix version for SSL 2.0 and remove version for SSL 1.0, porting FoxIO-LLC/ja4#150, a bug fix made in the JA4 spec in August 2024.  While here, also fix some versions mentioned in strings to match the code.

SSL 2.0 ([draft spec](https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html)) ([draft rfc](https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00)) uses a version field of 0x0002, not 0x0200.  SSL 1 never existed outside of Netscape, as the original design was iterated upon to become SSL 2 before the first public version of SSL.  I don't think it's public knowledge what the version field for SSL 1.0 looked like, or if it even was two bytes large or at the same offset on the wire.

Version field 0x0100, that nfdump is currently misattributing to SSL 1.0, was used by an early pre-RFC4347 implementation of DTLS in OpenSSL before 0.9.8f, when OpenSSL switched to the version field specified by RFC4347.

> [!CAUTION]
> I did not perform any testing.