### PR TITLE
Fixed a couple of memory leaks

### DIFF
--- a/src/nfdump/nfdump.c
+++ b/src/nfdump/nfdump.c
@@ -1318,6 +1318,9 @@ int main(int argc, char **argv) {
 
     }  // else - no output
 
+    // Free the multiple files list if used.
+    if (flist.multiple_files) free(flist.multiple_files);
+
     // Free the output params struct and the ident. At this point, the 'outputParams' pointer should never be NULL since thsis check exists further up.
     if (outputParams->ident) free(outputParams->ident);
     free(outputParams);

--- a/src/nfdump/nfdump.c
+++ b/src/nfdump/nfdump.c
@@ -557,6 +557,11 @@ static stat_record_t process_data(void *engine, int processMode, char *wfile, Re
     }
 
     recordHandle_t *recordHandle = calloc(1, sizeof(recordHandle_t));
+    if (!recordHandle)
+    {
+        LogError("calloc() failed in %s line %d.", __FILE__, __LINE__);
+        exit(255);
+    }
 
     // number of flows passed the filter
     dbg(uint32_t numBlocks = 0);
@@ -714,6 +719,9 @@ static stat_record_t process_data(void *engine, int processMode, char *wfile, Re
         }
         dbg_printf("processData() filter thread: %d\n", i);
     }
+
+    // Free the record handle.
+    if (recordHandle) free(recordHandle);
 
     totalPassed = filterArgs.passedRecords;
     skippedBlocks = prepareArgs.skippedBlocks;

--- a/src/nfdump/nfdump.c
+++ b/src/nfdump/nfdump.c
@@ -578,8 +578,11 @@ static stat_record_t process_data(void *engine, int processMode, char *wfile, Re
         dbg(numBlocks++);
         dataBlock_t *dataBlock = dataHandle->dataBlock;
         record_header_t *record_ptr = GetCursor(dataBlock);
-
         uint64_t recordCounter = dataHandle->recordCnt;
+
+        // Copy the strdupped ident string to the output params. When printing records, this string is printed.
+        // However, it needs to be freed before another value is set or we will have a memory leak.
+        if (outputParams->ident) free(outputParams->ident);
         outputParams->ident = dataHandle->ident;
 
         // successfully read block
@@ -687,8 +690,8 @@ static stat_record_t process_data(void *engine, int processMode, char *wfile, Re
 
         // Free the data handle here and the associated block. The 'ident' pointer is used elsewhere so this is freed elsewhere.
         FreeDataBlock(dataHandle->dataBlock);
-        if (dataHandle->ident) {
-            outputParams->ident = dataHandle->ident;
+        if (dataHandle)
+        {
             free(dataHandle);
         }
     }  // while


### PR DESCRIPTION
I found and fixed a couple of minor memory leaks in nfdump. I'm figuring out how nfdump works to investigate a performance issue with profiles so I might fix more small things.

Tested on FreeBSD, but the fixes target the source code and not the building process so I don't expect issues on Linux. Let me know if this works!