### PR TITLE
nfcapd: propagate subdirectory setting (-S) into dynamically added sources (with -M)

### DIFF
--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -59,6 +59,7 @@
 /* local variables */
 static uint32_t exporter_sysid = 0;
 static char *DynamicSourcesDir = NULL;
+static int DynamicSourcesSubDir = 0;
 
 /* local prototypes */
 static uint32_t AssignExporterID(void);
@@ -88,6 +89,10 @@ int SetDynamicSourcesDir(FlowSource_t **FlowSource, char *dir) {
     return 1;
 
 }  // End of SetDynamicSourcesDir
+
+void SetDynamicSourcesSubDir(int subdir_index) {
+    DynamicSourcesSubDir = subdir_index;
+} // End of SetDynamicSourcesSubDir
 
 int AddFlowSourceConfig(FlowSource_t **FlowSource) {
     char *ident, *ip, *flowdir;
@@ -342,6 +347,7 @@ FlowSource_t *AddDynamicSource(FlowSource_t **FlowSource, struct sockaddr_storag
         return NULL;
     }
     (*source)->datadir = strdup(path);
+    (*source)->subdir = DynamicSourcesSubDir;
 
     if (snprintf(path, MAXPATHLEN - 1, "%s/%s.%lu", (*source)->datadir, NF_DUMPFILE, (unsigned long)getpid()) >= (MAXPATHLEN - 1)) {
         LogError("Path too long: %s\n", path);

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -117,6 +117,7 @@ int AddFlowSourceConfig(FlowSource_t **FlowSource);
 int AddFlowSourceString(FlowSource_t **FlowSource, char *argument);
 
 int SetDynamicSourcesDir(FlowSource_t **FlowSource, char *dir);
+void SetDynamicSourcesSubDir(int subdir_index);
 
 FlowSource_t *AddDynamicSource(FlowSource_t **FlowSource, struct sockaddr_storage *ss);
 

--- a/src/nfcapd/nfcapd.c
+++ b/src/nfcapd/nfcapd.c
@@ -774,6 +774,10 @@ int main(int argc, char **argv) {
         }
     }
 
+    if (dynFlowDir && subdir_index) {
+        SetDynamicSourcesSubDir(subdir_index);
+    }
+
     if (!InitLog(do_daemonize, argv[0], SYSLOG_FACILITY, verbose)) {
         exit(EXIT_FAILURE);
     }

--- a/src/sflow/sfcapd.c
+++ b/src/sflow/sfcapd.c
@@ -751,6 +751,10 @@ int main(int argc, char **argv) {
         }
     }
 
+    if (dynFlowDir && subdir_index) {
+        SetDynamicSourcesSubDir(subdir_index);
+    }
+
     if (!InitLog(do_daemonize, argv[0], SYSLOG_FACILITY, verbose)) {
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
-S option (subdir topology) does not work with -M option (dynamically added sources) in nfcapd/sfcapd.

This small patch fixes that.