### PR TITLE
fix out-of-tree build

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd $(dirname $0)
+
 case "$(uname)" in
     Darwin)
         LIBTOOLIZE=${LIBTOOLIZE:-glibtoolize}

--- a/src/collector/Makefile.am
+++ b/src/collector/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline $(DEPS_CFLAGS) -D_BSD_SOURCE -D_DEFAULT_SOURCE
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline $(DEPS_CFLAGS) -D_BSD_SOURCE -D_DEFAULT_SOURCE
 
 EXTRA_DIST = collector_inline.c 
 

--- a/src/ft2nfdump/Makefile.am
+++ b/src/ft2nfdump/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline $(DEPS_CFLAGS)
 #AM_LDFLAGS  = -L../lib
 
 bin_PROGRAMS = ft2nfdump

--- a/src/libnfdump/Makefile.am
+++ b/src/libnfdump/Makefile.am
@@ -2,7 +2,7 @@
 BUILT_SOURCES = filter/grammar.h
 AM_YFLAGS = -d
 
-AM_CPPFLAGS = -I.. -I../include -I../inline -I../libnffile -Idecode -Isgregex $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../inline -I$(srcdir)/../libnffile -I$(srcdir)/decode -I$(srcdir)/sgregex -I$(srcdir)/filter $(DEPS_CFLAGS)
 AM_CFLAGS = -ggdb 
 
 LDADD =  $(DEPS_LIBS)

--- a/src/libnffile/Makefile.am
+++ b/src/libnffile/Makefile.am
@@ -1,6 +1,6 @@
 BUILT_SOURCES = vcs_track.h
 
-AM_CPPFLAGS = -I.. -I../include -I../inline -Iconf -Icompress $(DEPS_CFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../inline -I$(srcdir)/conf -I$(srcdir)/compress $(DEPS_CFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 AM_CFLAGS = -ggdb 
 
 LDADD =  $(DEPS_LIBS)
@@ -26,7 +26,7 @@ version = version.c version.h
 barrier = barrier.c barrier.h
 
 vcs_track.h: Makefile
-	./gen_version.sh
+	$(srcdir)/gen_version.sh
 
 lib_LTLIBRARIES = libnffile.la
 libnffile_la_SOURCES = $(conf) $(util) $(pidfile) $(compress) $(nffile) $(nflist) $(filter) $(output) $(regex) $(daemon) $(barrier) $(version) vcs_track.h

--- a/src/maxmind/Makefile.am
+++ b/src/maxmind/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnfdump -I../libnffile  -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnfdump -I$(srcdir)/../libnffile  -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 if MAXMIND
 bin_PROGRAMS = geolookup

--- a/src/netflow/Makefile.am
+++ b/src/netflow/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../libnffile -I../include -I../collector -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../libnffile -I$(srcdir)/../include -I$(srcdir)/../collector -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 noinst_LIBRARIES = libnetflow.a
 

--- a/src/nfanon/Makefile.am
+++ b/src/nfanon/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = nfanon
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 LDADD = $(DEPS_LIBS)
 

--- a/src/nfcapd/Makefile.am
+++ b/src/nfcapd/Makefile.am
@@ -2,7 +2,7 @@
 bin_PROGRAMS = nfcapd 
 
 AM_CFLAGS = -ggdb 
-AM_CPPFLAGS = -I../include -I../libnffile -I../inline -I../netflow -I../collector $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline -I$(srcdir)/../netflow -I$(srcdir)/../collector $(DEPS_CFLAGS)
 
 nfcapd_SOURCES = nfcapd.c 
 nfcapd_LDADD = ../netflow/libnetflow.a ../collector/libcollector.a -lnffile  -lm

--- a/src/nfdump/Makefile.am
+++ b/src/nfdump/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = nfdump
 
-AM_CPPFLAGS = -I.. -Icompat_1_6_x -I../include -I../libnffile -I../libnfdump -I../output -I../tor -I../netflow -I../collector -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/compat_1_6_x -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../libnfdump -I$(srcdir)/../output -I$(srcdir)/../tor -I$(srcdir)/../netflow -I$(srcdir)/../collector -I$(srcdir)/../inline $(DEPS_CFLAGS)
 AM_LDFLAGS  = -L../libnfdump -L../libnffile
 
 EXTRA_DIST = memhandle.c

--- a/src/nfexpire/Makefile.am
+++ b/src/nfexpire/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = nfexpire
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../collector $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../collector $(DEPS_CFLAGS)
 
 LDADD = $(DEPS_LIBS)
 

--- a/src/nfpcapd/Makefile.am
+++ b/src/nfpcapd/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = nfpcapd
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline -I../collector -I../netflow $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline -I$(srcdir)/../collector -I$(srcdir)/../netflow $(DEPS_CFLAGS)
 #AM_LDFLAGS  = -L../lib
 
 LDADD = $(DEPS_LIBS)

--- a/src/nfreader/Makefile.am
+++ b/src/nfreader/Makefile.am
@@ -1,7 +1,7 @@
 
 EXTRA_PROGRAMS = nfreader
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 LDADD = $(DEPS_LIBS)
 

--- a/src/nfreplay/Makefile.am
+++ b/src/nfreplay/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = nfreplay
 
-AM_CPPFLAGS = -I.. -I../include -I../libnfdump -I../libnffile -I../inline -I../collector -I../netflow $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnfdump -I$(srcdir)/../libnffile -I$(srcdir)/../inline -I$(srcdir)/../collector -I$(srcdir)/../netflow $(DEPS_CFLAGS)
 
 LDADD = $(DEPS_LIBS)
 

--- a/src/nfsen/Makefile.am
+++ b/src/nfsen/Makefile.am
@@ -1,6 +1,6 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../libnfdump -I../inline -I../collector 
-AM_CPPFLAGS += -I../libnffile/conf -I../libnfdump/maxmind -I../libnfdump/tor $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../libnfdump -I$(srcdir)/../inline -I$(srcdir)/../collector 
+AM_CPPFLAGS += -I$(srcdir)/../libnffile/conf -I$(srcdir)/../libnfdump/maxmind -I$(srcdir)/../libnfdump/tor $(DEPS_CFLAGS)
 
 bin_PROGRAMS = 
 

--- a/src/output/Makefile.am
+++ b/src/output/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../libnfdump -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../libnfdump -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 noinst_LIBRARIES = liboutput.a
 

--- a/src/sflow/Makefile.am
+++ b/src/sflow/Makefile.am
@@ -1,7 +1,7 @@
 
 bin_PROGRAMS = sfcapd
 
-AM_CPPFLAGS = -I.. -I../include -I../libnffile -I../inline -I../collector $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnffile -I$(srcdir)/../inline -I$(srcdir)/../collector $(DEPS_CFLAGS)
 
 sflow = sflow_nfdump.c sflow_nfdump.h sflow.h sflow_v2v4.h sflow_process.c  sflow_process.h
 sfcapd_SOURCES = sfcapd.c \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -20,7 +20,7 @@ TEST_BZIP2="$(TEST_BZIP2)"; export TEST_BZIP2 \
 TEST_ZSTD="$(TEST_ZSTD)"; export TEST_ZSTD \
 ;
 
-AM_CPPFLAGS = -I.. -I../include -I../libnfdump -I../libnffile -I../inline -I../netflow -I../collector $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnfdump -I$(srcdir)/../libnffile -I$(srcdir)/../inline -I$(srcdir)/../netflow -I$(srcdir)/../collector $(DEPS_CFLAGS)
 AM_CFLAGS = -ggdb
 AM_LDFLAGS  = -L../lib
 

--- a/src/tor/Makefile.am
+++ b/src/tor/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I.. -I../include -I../libnfdump -I../libnffile -I../inline $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. -I$(srcdir)/../include -I$(srcdir)/../libnfdump -I$(srcdir)/../libnffile -I$(srcdir)/../inline $(DEPS_CFLAGS)
 
 if TORLOOKUP
 bin_PROGRAMS = torlookup


### PR DESCRIPTION
This mostly consists of prefixing with `$(srcdir)` where needed.