### PR TITLE
Add TCP Flags aggregation option

### DIFF
--- a/man/nfdump.1
+++ b/man/nfdump.1
@@ -280,6 +280,8 @@ Source type of service
 Source type of Service
 .It Cm dsttos
 Destination type of Service
+.It Cm flags
+TCP flags
 .It Cm mpls1
 MPLS label 1
 .It Cm mpls2

--- a/src/nfdump/nflowcache.c
+++ b/src/nfdump/nflowcache.c
@@ -99,6 +99,7 @@ static struct aggregationElement_s {
                         {"dstport", {EXgenericFlowID, OFFdstPort, SIZEdstPort, 0}, 0, NOPREPROCESS, 0, 0, "%dp"},
                         {"tos", {EXgenericFlowID, OFFsrcTos, SIZEsrcTos, 0}, 0, NOPREPROCESS, 0, 0, "%tos"},
                         {"srctos", {EXgenericFlowID, OFFsrcTos, SIZEsrcTos, 0}, 0, NOPREPROCESS, 0, 0, "%stos"},
+                        {"flags", {EXgenericFlowID, OFFtcpFlags, SIZEtcpFlags, 0}, 0, NOPREPROCESS, 0, 0, "%flg"},
                         {"srcip4", {EXipv4FlowID, OFFsrc4Addr, SIZEsrc4Addr, AF_INET}, 0, NOPREPROCESS, 0, 1, "%sa"},
                         {"dstip4", {EXipv4FlowID, OFFdst4Addr, SIZEdst4Addr, AF_INET}, 0, NOPREPROCESS, 0, 2, "%da"},
                         {"srcip6", {EXipv6FlowID, OFFsrc6Addr, SIZEsrc6Addr, AF_INET6}, 0, NOPREPROCESS, 0, 1, "%sa"},


### PR DESCRIPTION
Hi @phaag,

First of all, thank you for your great work on nfdump, it's an incredibly tool!

While analyzing a SYN Flood DDoS attack recently, I noticed that nfdump currently doesn't provide an option to aggregate traffic by TCP Flags. I double-checked the latest versions and couldn’t find such functionality:

<img width="1038" height="99" alt="image" src="https://github.com/user-attachments/assets/b8f9f468-84bf-4606-a7a0-795ba2c4009e" />

I've implemented an option to add this feature, and it seems to be working as intended:

<img width="1348" height="876" alt="image" src="https://github.com/user-attachments/assets/06cca018-766b-42f7-a81e-0daf4f44f89b" />

Could you please review this implementation and share your thoughts?
Do you think this would be a useful addition for other users as well?

Thanks again for maintaining such a great project!

Best regards,
Murilo Chianfa