### PR TITLE
Reduce minimum nfcapd time to 1 second

### DIFF
--- a/man/nfcapd.1
+++ b/man/nfcapd.1
@@ -263,7 +263,7 @@ The following hierarchies are defined:
 .El
 .It Fl t Ar interval
 Sets the time interval in seconds to rotate files. The default value is 300s ( 5min ).
-The smallest available interval is 2s.
+The smallest available interval is 1s.
 .It Fl s Ar rate
 Apply sampling rate
 .Ar rate

--- a/man/nfpcapd.1
+++ b/man/nfpcapd.1
@@ -124,7 +124,7 @@ The base directory (
 .Fl l )
 is concatenated with the specified sub hierarchy format to form the final data directory. For a full list of hierarchies see nfcapd(1).
 .It Fl t Ar interval
-Specifies the time interval in seconds to rotate files. The default value is 300s ( 5min ). The smallest interval can be set to 2s. The intervals are in sync with wall clock.
+Specifies the time interval in seconds to rotate files. The default value is 300s ( 5min ). The smallest interval can be set to 1s. The intervals are in sync with wall clock.
 .It Fl P Ar pidfile
 Specify name of pidfile. Default is no pidfile.
 .It Fl D

--- a/man/sfcapd.1
+++ b/man/sfcapd.1
@@ -227,7 +227,7 @@ The following hierarchies are defined:
 .El
 .It Fl t Ar interval
 Sets the time interval in seconds to rotate files. The default value is 300s ( 5min ).
-The smallest available interval is 2s.
+The smallest available interval is 1s.
 .It Fl z=lzo
 Compress flow files with LZO1X-1 compression. Fastest compression.
 .It Fl z=bz2

--- a/src/nfcapd/nfcapd.c
+++ b/src/nfcapd/nfcapd.c
@@ -295,8 +295,8 @@ static void run(collector_ctx_t *ctx, packet_function_t receive_packet, int sock
     uint32_t ignored_packets = 0;
     uint64_t packets = 0;
 
-    // wake up at least at next time slot (twin) + 1s
-    alarm(t_start + twin + 1 - time(NULL));
+    // wake up at next time slot (twin) for precise rotation
+    alarm(t_start + twin - time(NULL));
     /*
      * Main processing loop:
      * this loop, continues until  = 1, set by the signal handler
@@ -374,11 +374,10 @@ static void run(collector_ctx_t *ctx, packet_function_t receive_packet, int sock
              * update alarm for next cycle
              * t_start = filename time stamp: begin of slot
              * + twin = end of next time interval
-             * + 1 = act at least 1s after time window expired
              * - t_now = difference value to now
              */
             t_start += twin;
-            alarm(t_start + twin + 1 - t_now);
+            alarm(t_start + twin - t_now);
         }
 
         /* check for EINTR and continue */
@@ -694,8 +693,8 @@ int main(int argc, char **argv) {
                 break;
             case 't':
                 twin = atoi(optarg);
-                if (twin < 2) {
-                    LogError("time interval <= 2s not allowed");
+                if (twin < 1) {
+                    LogError("time interval < 1s not allowed");
                     exit(EXIT_FAILURE);
                 }
                 if (twin < 60) {

--- a/src/nfpcapd/nfpcapd.c
+++ b/src/nfpcapd/nfpcapd.c
@@ -443,8 +443,8 @@ int main(int argc, char *argv[]) {
             } break;
             case 't':
                 t_win = atoi(optarg);
-                if (t_win < 2) {
-                    LogError("time interval <= 2s not allowed");
+                if (t_win < 1) {
+                    LogError("time interval < 1s not allowed");
                     exit(EXIT_FAILURE);
                 }
                 if (t_win < 60) {

--- a/src/sflow/sfcapd.c
+++ b/src/sflow/sfcapd.c
@@ -292,8 +292,8 @@ static void run(collector_ctx_t *ctx, packet_function_t receive_packet, int sock
     uint32_t ignored_packets = 0;
     uint64_t packets = 0;
 
-    // wake up at least at next time slot (twin) + 1s
-    alarm(t_start + twin + 1 - time(NULL));
+    // wake up at next time slot (twin) for precise rotation
+    alarm(t_start + twin - time(NULL));
     /*
      * Main processing loop:
      * this loop, continues until  = 1, set by the signal handler
@@ -352,11 +352,10 @@ static void run(collector_ctx_t *ctx, packet_function_t receive_packet, int sock
              * update alarm for next cycle
              * t_start = filename time stamp: begin of slot
              * + twin = end of next time interval
-             * + 1 = act at least 1s after time window expired
              * - t_now = difference value to now
              */
             t_start += twin;
-            alarm(t_start + twin + 1 - t_now);
+            alarm(t_start + twin - t_now);
         }
 
         /* check for EINTR and continue */
@@ -643,8 +642,8 @@ int main(int argc, char **argv) {
                 break;
             case 't':
                 twin = atoi(optarg);
-                if (twin < 2) {
-                    LogError("time interval <= 2s not allowed");
+                if (twin < 1) {
+                    LogError("time interval < 1s not allowed");
                     exit(EXIT_FAILURE);
                 }
                 if (twin < 60) {


### PR DESCRIPTION
Hey @phaag,

I'm trying to reduce to 1 second the nfcapd rotation time and so far it looks good, there is any reason that I should be aware on why you restricted into 2 seconds? or else we could reduce it, maybe into sub-seconds later. 👀👀 

### Tests Made

NetFlow v9 exporter exporting to port 2055, then an samplicator listening and replaying to two different **nfcapd**:
```
docker run -d --name samplicator --network host elastiflow/samplicator:1.0.1_1.3.8rc1 -s 0.0.0.0 -p 2055 127.0.0.1/9000 127.0.0.1/9001
```

Now, one baseline **nfcapd** listening using -t 2:
```
/usr/local/bin/nfcapd -p 9001 -w /tmp/test-2sec -I baseline -t 2 -D
```

And the new version using -t 1:
```
./src/nfcapd/nfcapd -p 9000 -w /tmp/test-1sec -I new -t 1 -D
```

After some time, they both captured the same traffic:
```
[murilo@workstation: nfdump]$ nfdump -R /tmp/test-1sec -A router
Date first seen         Duration                 Router IP   Packets    Bytes      bps    Bpp Flows
2026-01-30 22:11:47.000     00:01:29.000         127.0.0.1     38622   36.7 M    3.3 M    950 10307
Summary: total flows: 10307, total bytes: 36.7 M, total packets: 38622, avg bps: 3.3 M, avg pps: 433, avg bpp: 950
Time window: 2026-01-30 22:11:47.000 - 2026-01-30 22:13:16.000, Duration:    00:01:29.000
Total records processed: 10307, passed: 10307, Blocks skipped: 0, Bytes read: 2180628
Sys: 0.0638s User: 0.1913s Wall: 0.0015s flows/second: 7002055.6 Runtime: 0.0015s
[murilo@workstation: nfdump]$ 
[murilo@workstation: nfdump]$ nfdump -R /tmp/test-2sec -A router
Date first seen         Duration                 Router IP   Packets    Bytes      bps    Bpp Flows
2026-01-30 22:11:47.000     00:01:29.000         127.0.0.1     38622   36.7 M    3.3 M    950 10307
Summary: total flows: 10307, total bytes: 36.7 M, total packets: 38622, avg bps: 3.3 M, avg pps: 433, avg bpp: 950
Time window: 2026-01-30 22:11:47.000 - 2026-01-30 22:13:16.000, Duration:    00:01:29.000
Total records processed: 10307, passed: 10307, Blocks skipped: 0, Bytes read: 2178708
Sys: 0.0636s User: 0.1888s Wall: 0.0012s flows/second: 8909870.4 Runtime: 0.0012s
```

> [!NOTE]
> They both had 10307 flows

---

This test was made only using NetFlow v9. Further tests may be needed with sflow on **sfcapd** and raw packets in **nfpcapd**. Let me know you thoughts about. Thanks.
