### PR TITLE
Fix IPv6 destination anonymization using wrong address

### DIFF
--- a/src/nfanon/nfanon.c
+++ b/src/nfanon/nfanon.c
@@ -209,7 +209,7 @@ static inline void AnonRecord(recordHeaderV3_t *v3Record, int anon_src, int anon
                 }
 
                 if (anon_dst) {
-                    anonymize_v6(ipv6Flow->srcAddr, anon_ip);
+                    anonymize_v6(ipv6Flow->dstAddr, anon_ip);
                     ipv6Flow->dstAddr[0] = anon_ip[0];
                     ipv6Flow->dstAddr[1] = anon_ip[1];
                 }


### PR DESCRIPTION
Found a copy-paste issue in `nfanon.c` — the IPv6 destination
anonymization block is passing `ipv6Flow->srcAddr` to `anonymize_v6()`
instead of `ipv6Flow->dstAddr`. So the anonymized destination ends up
being derived from the source address, not the actual destination.

This breaks the flow relationship in the anonymized output for any
IPv6 traffic since both addresses end up based on the same source.

One-line fix — just `srcAddr` → `dstAddr` on the `anonymize_v6` call
inside the `anon_dst` block.

I ran into this while reading through the code to integrate nfanon
into a project I'm working on. The IPv4 path handles it correctly,
so this looks like it was just a copy-paste slip from the src block
above it.