### PR TITLE
Validate v5/v7 packet header length before parsing

### DIFF
--- a/src/netflow/netflow_v5_v7.c
+++ b/src/netflow/netflow_v5_v7.c
@@ -296,6 +296,11 @@ static inline exporter_entry_t *getExporter(FlowSource_t *fs, netflow_v5_header_
 }  // End of getExporter
 
 void Process_v5_v7(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs) {
+    if (in_buff_cnt < NETFLOW_V5_HEADER_LENGTH) {
+        LogError("Process_v5: Too little data for v5/v7 packet: '%lli'", (long long)in_buff_cnt);
+        return;
+    }
+
     // v7 is treated as v5. it differs by the sequencer skip count only
     // map v5 data structure to input buffer
     netflow_v5_header_t *v5_header = (netflow_v5_header_t *)in_buff;

--- a/src/netflow/nfd_raw.c
+++ b/src/netflow/nfd_raw.c
@@ -154,6 +154,11 @@ static void *GetExtension(recordHeaderV3_t *recordHeader, int extensionID) {
 }  // End of GetExtension
 
 void Process_nfd(void *in_buff, ssize_t in_buff_cnt, FlowSource_t *fs) {
+    if (in_buff_cnt < (ssize_t)sizeof(nfd_header_t)) {
+        LogError("Process_nfd: Too little data for nfd packet: '%lli'", (long long)in_buff_cnt);
+        return;
+    }
+
     // map pacpd data structure to input buffer
     nfd_header_t *pcapd_header = (nfd_header_t *)in_buff;
 


### PR DESCRIPTION
`Process_v5_v7()` reads v5/v7 header fields before checking that the supplied buffer contains a complete v5/v7 header.

This is primarily relevant for library-style/direct parser callers that pass an exact-sized short buffer: those callers can trigger an OOB read before the parser rejects the packet.

For `nfcapd` itself, short UDP packets are received into a larger reusable network buffer, so this path reads stale data inside that allocation rather than producing an OOB read; the packet is then rejected as too short.

This patch moves the minimum v5/v7 header length check before the header is used.

Verified with ASan using short v5/v7 packet reproducers and rebuilt `libnetflow`/`nfcapd`.
