### PR TITLE
Potential fix for code scanning alert no. 69: Wrong type of arguments to formatting function

### DIFF
--- a/src/sflow/sfcapd.c
+++ b/src/sflow/sfcapd.c
@@ -319,7 +319,7 @@ static void run(collector_ctx_t *ctx, packet_function_t receive_packet, int sock
 
             if (cnt == -1) {
                 if (errno != EINTR) {
-                    LogError("recvfrom() error in '%s', line '%d', cnt: %d:, %s", __FILE__, __LINE__, cnt, strerror(errno));
+                    LogError("recvfrom() error in '%s', line '%d', cnt: %zd:, %s", __FILE__, __LINE__, cnt, strerror(errno));
                     continue;
                 }
             } else {


### PR DESCRIPTION
Potential fix for [https://github.com/phaag/nfdump/security/code-scanning/69](https://github.com/phaag/nfdump/security/code-scanning/69)

The fix is to align the format specifier with the actual argument type of `cnt` (`ssize_t`).  
In `src/sflow/sfcapd.c`, update the `LogError` format string at the recvfrom error path (around line 322) from `%d` to `%zd` for `cnt`.

This is the minimal, behavior-preserving fix:
- No logic changes.
- No new methods/definitions needed.
- No imports needed (already includes standard headers; `%zd` support is from standard `printf` formatting).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
